### PR TITLE
Add proxy for frontend

### DIFF
--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -1,4 +1,4 @@
-import { handleRequest } from '../src/frontend-proxy'
+import { handleRequest, formatFrontendCookie } from '../src/frontend-proxy'
 
 describe('handleRequest()', () => {
   describe('returns null if language tenant is not "de"', () => {
@@ -11,4 +11,9 @@ describe('handleRequest()', () => {
       expect(await handleRequest(new Request(url))).toBeNull()
     })
   })
+})
+
+test('formatFrontendCookie()', () => {
+  expect(formatFrontendCookie(true)).toBe('useFrontend=true; path=/')
+  expect(formatFrontendCookie(false)).toBe('useFrontend=false; path=/')
 })

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -11,6 +11,15 @@ describe('handleRequest()', () => {
       expect(await handleRequest(new Request(url))).toBeNull()
     })
   })
+
+  test('requests to /enable-frontend enable use of frontend', async () => {
+    const url = 'https://de.serlo.org/enable-frontend'
+    const res = (await handleRequest(new Request(url))) as Response
+
+    expect(res).not.toBeNull()
+    expect(res.headers.get('Set-Cookie')).toBe(formatFrontendCookie(true))
+    expect(await res.text()).toBe('Enable frontend')
+  })
 })
 
 test('formatFrontendCookie()', () => {

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -237,7 +237,7 @@ describe('handleRequest()', () => {
     expect(response).not.toBe(backendResponse)
   })
 
-  describe('transfers request meta data to backend', () => {
+  describe('transfers request headers to backend', () => {
     test.each([1, 0])('useFrontendProbability=%p', async (probability) => {
       const mockedFetch = mockFetchReturning('')
       global.FRONTEND_PROBABILITY = probability.toString()
@@ -254,7 +254,7 @@ describe('handleRequest()', () => {
     })
   })
 
-  describe('transfers response meta data from backend', () => {
+  describe('transfers response headers from backend', () => {
     test.each([1, 0])('useFrontendProbability=%p', async (probability) => {
       mockFetchReturning(
         new Response('', {

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -1,11 +1,15 @@
-import { handleRequest, FRONTEND_DOMAIN } from '../src/frontend-proxy'
+import {
+  handleRequest,
+  FRONTEND_DOMAIN,
+  createApiQuery,
+} from '../src/frontend-proxy'
+import { createJsonResponse } from '../src/utils'
 import { withMockedFetch, hasOkStatus } from './utils'
 
-describe('handleRequest()', () => {
-  async function handleUrl(url: string, probability = 0.1) {
-    return (await handleRequest(new Request(url), probability)) as Response
-  }
+const TEST_ALLOWED_TYPES = ['User', 'Article']
+const testUrl = 'https://de.serlo.org/example-url'
 
+describe('handleRequest()', () => {
   describe('returns null if language tenant is not "de"', () => {
     test.each([
       'https://serlo.org/',
@@ -19,22 +23,40 @@ describe('handleRequest()', () => {
 
   describe('chooses backend based on probability', () => {
     test.each([
-      [1, 'frontend', true],
-      [0, 'no-frontend', false],
+      [1, TEST_ALLOWED_TYPES[0], 'frontend', true],
+      [1, TEST_ALLOWED_TYPES[1], 'frontend', true],
+      [0, TEST_ALLOWED_TYPES[0], 'no-frontend', false],
+      [0, TEST_ALLOWED_TYPES[1], 'no-frontend', false],
     ])(
       'probability=%p',
-      async (probability, responseText, useFrontendCookie) => {
-        await withMockedFetch(checkFrontendRequest, async () => {
-          const req = new Request('https://de.serlo.org/example')
-          const res = (await handleRequest(req, probability)) as Response
+      async (probability, typename, responseText, useFrontendCookie) => {
+        await withMockedFetch(
+          [createApiResponse(typename), checkFrontendRequest],
+          async () => {
+            const res = await handleUrl(testUrl, probability)
 
-          expect(await res.text()).toBe(responseText)
-          expect(res.headers.get('Set-Cookie')).toBe(
-            `useFrontend${probability * 100}=${useFrontendCookie}; path=/`
-          )
-        })
+            expect(await res.text()).toBe(responseText)
+            expect(res.headers.get('Set-Cookie')).toBe(
+              `useFrontend${probability * 100}=${useFrontendCookie}; path=/`
+            )
+          }
+        )
       }
     )
+  })
+
+  describe('returns null for not allowed taxonomy types', () => {
+    test.each(['Page', 'TaxonomyTerm'])('typename=%p', async (typename) => {
+      await withMockedFetch([createApiResponse(typename)], async () => {
+        expect(await handleUrl(testUrl, 1)).toBeNull()
+      })
+    })
+  })
+
+  test('returns null for unknown paths', async () => {
+    await withMockedFetch([createApiErrorResponse()], async () => {
+      expect(await handleUrl(testUrl, 1)).toBeNull()
+    })
   })
 
   describe('requests to /_next always resolve to frontend', () => {
@@ -42,7 +64,7 @@ describe('handleRequest()', () => {
       'https://de.serlo.org/_next/script.js',
       'https://de.serlo.org/_next/img/picture.svg',
     ])('URL is %p', async (url) => {
-      await withMockedFetch(checkFrontendRequest, async () => {
+      await withMockedFetch([checkFrontendRequest], async () => {
         const response = await handleUrl(url)
 
         expect(await response.text()).toBe('frontend')
@@ -52,37 +74,51 @@ describe('handleRequest()', () => {
   })
 
   test('uses frontend when it is enabled via cookie', async () => {
-    await withMockedFetch(checkFrontendRequest, async () => {
-      const request = new Request('https://de.serlo.org/example')
-      request.headers.set('Cookie', 'useFrontend75=true;')
+    await withMockedFetch(
+      [createApiResponse(), checkFrontendRequest],
+      async () => {
+        const res = await handleUrl(testUrl, 0, 'useFrontend0=true;')
 
-      const response = (await handleRequest(request, 0.75)) as Response
-      expect(response.headers.get('Set-Cookie')).toBeNull()
-      expect(await response.text()).toBe('frontend')
-    })
+        expect(res.headers.get('Set-Cookie')).toBeNull()
+        expect(await res.text()).toBe('frontend')
+      }
+    )
   })
 
   test('do not use fronted when it is disabled via cookie', async () => {
-    await withMockedFetch(checkFrontendRequest, async () => {
-      const request = new Request('https://de.serlo.org/example')
-      request.headers.set('Cookie', 'useFrontend75=false;')
+    await withMockedFetch(
+      [createApiResponse(), checkFrontendRequest],
+      async () => {
+        const res = await handleUrl(testUrl, 1, 'useFrontend100=false;')
 
-      const response = (await handleRequest(request, 0.75)) as Response
-      expect(response.headers.get('Set-Cookie')).toBeNull()
-      expect(await response.text()).toBe('no-frontend')
+        expect(res.headers.get('Set-Cookie')).toBeNull()
+        expect(await res.text()).toBe('no-frontend')
+      }
+    )
+  })
+
+  test('creates new response object for calls to frontend', async () => {
+    const frontendResponse = new Response('')
+
+    await withMockedFetch([createApiResponse(), frontendResponse], async () => {
+      const res = await handleUrl(testUrl, 1)
+      expect(res).not.toBe(frontendResponse)
     })
   })
 
   describe('transfers request meta data to backend', () => {
     test.each([true, false])('useFrontend=%p', async (useFrontend) => {
-      await withMockedFetch(checkRequestData, async () => {
-        const request = new Request('https://de.serlo.org/example')
-        request.headers.set('Cookie', `useFrontend20=${useFrontend};`)
-        request.headers.set('X-Header', 'foo')
+      await withMockedFetch(
+        [createApiResponse(), checkRequestData],
+        async () => {
+          const cookie = `useFrontend20=${useFrontend};`
+          const response = await handleUrl(testUrl, 0.2, cookie, {
+            headers: { 'X-Header': 'foo' },
+          })
 
-        const response = (await handleRequest(request, 0.2)) as Response
-        expect(await response.text()).toBe('header-shown')
-      })
+          expect(await response.text()).toBe('header-shown')
+        }
+      )
 
       function checkRequestData(req: Request) {
         const res =
@@ -97,18 +133,15 @@ describe('handleRequest()', () => {
 
   describe('transfers response meta data from backend', () => {
     test.each([true, false])('useFrontend=%p', async (useFrontend) => {
-      const targetResponse = new Response('hello', {
-        headers: {
-          'X-Header': 'bar',
-        },
+      const targetResponse = new Response('', {
+        headers: { 'X-Header': 'bar' },
       })
 
-      await withMockedFetch(targetResponse, async () => {
-        const request = new Request('https://de.serlo.org/example')
-        request.headers.set('Cookie', `useFrontend20=${useFrontend};`)
+      await withMockedFetch([createApiResponse(), targetResponse], async () => {
+        const cookie = `useFrontend20=${useFrontend};`
+        const res = await handleUrl(testUrl, 0.2, cookie)
 
-        const response = (await handleRequest(request, 0.2)) as Response
-        expect(response.headers.get('X-Header')).toBe('bar')
+        expect(res.headers.get('X-Header')).toBe('bar')
       })
     })
   })
@@ -131,6 +164,44 @@ describe('handleRequest()', () => {
     expect(await res.text()).toBe('Disable frontend')
   })
 })
+
+test('createApiQuery()', () => {
+  expect(createApiQuery('/math')).toBe(
+    '{ uuid(alias: { instance: de, path: "/math" }) { __typename } }'
+  )
+  expect(createApiQuery('hello')).toBe(
+    '{ uuid(alias: { instance: de, path: "/hello" }) { __typename } }'
+  )
+  expect(createApiQuery('/266/')).toBe(
+    '{ uuid(alias: { instance: de, path: "/266/" }) { __typename } }'
+  )
+  expect(createApiQuery('/266')).toBe('{ uuid(id: 266) { __typename } }')
+  expect(createApiQuery('/874329')).toBe('{ uuid(id: 874329) { __typename } }')
+})
+
+async function handleUrl(
+  url: string,
+  probability = 0.1,
+  cookie?: string,
+  reqInit?: RequestInit
+) {
+  const req = new Request(url, reqInit)
+
+  if (cookie !== undefined) req.headers.set('Cookie', cookie)
+
+  return (await handleRequest(req, probability, TEST_ALLOWED_TYPES)) as Response
+}
+
+function createApiResponse(typename = TEST_ALLOWED_TYPES[0]) {
+  return createJsonResponse({ data: { uuid: { __typename: typename } } })
+}
+
+function createApiErrorResponse() {
+  return createJsonResponse({
+    errors: [{ message: 'error' }],
+    data: { uuid: null },
+  })
+}
 
 function checkFrontendRequest(req: Request) {
   const res =

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -20,6 +20,15 @@ describe('handleRequest()', () => {
     expect(res.headers.get('Set-Cookie')).toBe(formatFrontendCookie(true))
     expect(await res.text()).toBe('Enable frontend')
   })
+
+  test('requests to /disable-frontend disable use of frontend', async () => {
+    const url = 'https://de.serlo.org/disable-frontend'
+    const res = (await handleRequest(new Request(url))) as Response
+
+    expect(res).not.toBeNull()
+    expect(res.headers.get('Set-Cookie')).toBe(formatFrontendCookie(false))
+    expect(await res.text()).toBe('Disable frontend')
+  })
 })
 
 test('formatFrontendCookie()', () => {

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -10,7 +10,7 @@ describe('handleRequest()', () => {
     global.FRONTEND_PROBABILITY = '0.1'
     global.FRONTEND_ALLOWED_TYPES = '[]'
 
-    mockKV('FRONTEND_CACHE_TYPES', {})
+    mockKV('FRONTEND_CACHE_TYPES_KV', {})
   })
 
   const randomCopy = Math.random
@@ -53,7 +53,9 @@ describe('handleRequest()', () => {
       expect(cookieHeader).toBe('useFrontend=0.25; path=/')
 
       expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
-      const cachedType = await global.FRONTEND_CACHE_TYPES.get(getPathname(url))
+      const cachedType = await global.FRONTEND_CACHE_TYPES_KV.get(
+        getPathname(url)
+      )
       expect(cachedType).toBe('User')
     })
   })
@@ -79,7 +81,9 @@ describe('handleRequest()', () => {
 
       expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
 
-      const cachedType = await global.FRONTEND_CACHE_TYPES.get(getPathname(url))
+      const cachedType = await global.FRONTEND_CACHE_TYPES_KV.get(
+        getPathname(url)
+      )
       expect(cachedType).toBe('User')
     })
   })
@@ -97,7 +101,7 @@ describe('handleRequest()', () => {
     expect(response.headers.get('Set-Cookie')).toBeNull()
     expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
 
-    const cachedType = await global.FRONTEND_CACHE_TYPES.get('/math')
+    const cachedType = await global.FRONTEND_CACHE_TYPES_KV.get('/math')
     expect(cachedType).toBeNull()
   })
 
@@ -105,13 +109,13 @@ describe('handleRequest()', () => {
     const mockedFetch = mockFetchReturning('')
     global.FRONTEND_PROBABILITY = '1'
     global.FRONTEND_ALLOWED_TYPES = '["Page"]'
-    await global.FRONTEND_CACHE_TYPES.put('/math', 'Page')
+    await global.FRONTEND_CACHE_TYPES_KV.put('/math', 'Page')
 
     const request = new Request('https://de.serlo.org/math')
     await handleRequest(request)
 
     expect(getBackendUrl(mockedFetch)).toBe('https://frontend.domain/math')
-    expect(await global.FRONTEND_CACHE_TYPES.get('/math')).toBe('Page')
+    expect(await global.FRONTEND_CACHE_TYPES_KV.get('/math')).toBe('Page')
   })
 
   test('type of start page is not checked', async () => {
@@ -125,7 +129,7 @@ describe('handleRequest()', () => {
     expect(getBackendUrl(mockedFetch)).toBe('https://frontend.domain/')
     expect(response.headers.get('Set-Cookie')).toBe(`useFrontend=0.25; path=/`)
     expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
-    expect(await global.FRONTEND_CACHE_TYPES.get('/')).toBeNull()
+    expect(await global.FRONTEND_CACHE_TYPES_KV.get('/')).toBeNull()
   })
 
   describe('returns null for not allowed taxonomy types', () => {
@@ -138,7 +142,7 @@ describe('handleRequest()', () => {
       const response = await handleRequest(request)
 
       expect(response).toBeNull()
-      expect(await global.FRONTEND_CACHE_TYPES.get('/math')).toBe(typename)
+      expect(await global.FRONTEND_CACHE_TYPES_KV.get('/math')).toBe(typename)
     })
   })
 
@@ -149,7 +153,7 @@ describe('handleRequest()', () => {
     const response = await handleRequest(request)
 
     expect(response).toBeNull()
-    expect(await global.FRONTEND_CACHE_TYPES.get('/math')).toBeNull()
+    expect(await global.FRONTEND_CACHE_TYPES_KV.get('/math')).toBeNull()
   })
 
   describe('requests to /_next, /api/frontend and /_assets always resolve to frontend', () => {
@@ -169,7 +173,9 @@ describe('handleRequest()', () => {
       expect(getBackendUrl(mockedFetch)).toBe(targetUrl)
       expect(response.headers.get('Set-Cookie')).toBeNull()
       expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
-      expect(await global.FRONTEND_CACHE_TYPES.get(getPathname(url))).toBeNull()
+      expect(
+        await global.FRONTEND_CACHE_TYPES_KV.get(getPathname(url))
+      ).toBeNull()
     })
   })
 
@@ -199,7 +205,7 @@ describe('handleRequest()', () => {
         expect(Math.random).not.toHaveBeenCalled()
 
         const path = getPathname(url)
-        const cachedType = await global.FRONTEND_CACHE_TYPES.get(path)
+        const cachedType = await global.FRONTEND_CACHE_TYPES_KV.get(path)
         expect(cachedType).toBe('User')
       })
 
@@ -221,7 +227,7 @@ describe('handleRequest()', () => {
         expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
 
         const path = getPathname(url)
-        const cachedType = await global.FRONTEND_CACHE_TYPES.get(path)
+        const cachedType = await global.FRONTEND_CACHE_TYPES_KV.get(path)
         expect(cachedType).toBe('User')
       })
     })

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -84,10 +84,13 @@ describe('handleRequest()', () => {
         expect(await response.text()).toBe('header-shown')
       })
 
-      async function checkRequestData(request: Request) {
-        return request.headers.get('X-Header') === 'foo'
-          ? new Response('header-shown')
-          : new Response('no-header')
+      function checkRequestData(req: Request) {
+        const res =
+          req.headers.get('X-Header') === 'foo'
+            ? new Response('header-shown')
+            : new Response('no-header')
+
+        return new Promise<Response>((resolve) => resolve(res))
       }
     })
   })
@@ -129,10 +132,11 @@ describe('handleRequest()', () => {
   })
 })
 
-async function checkFrontendRequest(req: Request): Promise<Response> {
-  if (new URL(req.url).hostname === FRONTEND_DOMAIN) {
-    return new Response('frontend')
-  } else {
-    return new Response('no-frontend')
-  }
+function checkFrontendRequest(req: Request) {
+  const res =
+    new URL(req.url).hostname === FRONTEND_DOMAIN
+      ? new Response('frontend')
+      : new Response('no-frontend')
+
+  return new Promise<Response>((resolve) => resolve(res))
 }

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -84,6 +84,23 @@ describe('handleRequest()', () => {
     })
   })
 
+  test('uses standard backend for authenticated user', async () => {
+    const mockedFetch = mockFetchReturning('')
+    global.FRONTEND_PROBABILITY = '1'
+    global.FRONTEND_ALLOWED_TYPES = '["Page"]'
+
+    const request = new Request('https://de.serlo.org/math')
+    request.headers.set('Cookie', 'authenticated=1')
+    const response = (await handleRequest(request))!
+
+    expect(getBackendUrl(mockedFetch)).toBe('https://de.serlo.org/math')
+    expect(response.headers.get('Set-Cookie')).toBeNull()
+    expect(getHeaderApiEndpoint(mockedFetch)).toBe('api.endpoint')
+
+    const cachedType = await global.FRONTEND_CACHE_TYPES.get('/math')
+    expect(cachedType).toBeNull()
+  })
+
   test('Uses cache to determine the type of an path', async () => {
     const mockedFetch = mockFetchReturning('')
     global.FRONTEND_PROBABILITY = '1'

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -307,18 +307,16 @@ describe('handleRequest()', () => {
   })
 })
 
-test('createApiQuery()', () => {
-  expect(createApiQuery('/math')).toBe(
-    '{ uuid(alias: { instance: de, path: "/math" }) { __typename } }'
-  )
-  expect(createApiQuery('hello')).toBe(
-    '{ uuid(alias: { instance: de, path: "/hello" }) { __typename } }'
-  )
-  expect(createApiQuery('/266/')).toBe(
-    '{ uuid(alias: { instance: de, path: "/266/" }) { __typename } }'
-  )
-  expect(createApiQuery('/266')).toBe('{ uuid(id: 266) { __typename } }')
-  expect(createApiQuery('/874329')).toBe('{ uuid(id: 874329) { __typename } }')
+describe('createApiQuery()', () => {
+  test('alias path', () => {
+    expect(createApiQuery('/math')).toBe(
+      '{ uuid(alias: { instance: de, path: "/math" }) { __typename } }'
+    )
+  })
+
+  test('path with uuid', () => {
+    expect(createApiQuery('/266')).toBe('{ uuid(id: 266) { __typename } }')
+  })
 })
 
 function createApiResponse(typename: string) {

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -1,4 +1,4 @@
-import { handleRequest, formatFrontendCookie } from '../src/frontend-proxy'
+import { handleRequest, formatFrontendUsageCookie } from '../src/frontend-proxy'
 
 describe('handleRequest()', () => {
   describe('returns null if language tenant is not "de"', () => {
@@ -17,7 +17,7 @@ describe('handleRequest()', () => {
     const res = (await handleRequest(new Request(url))) as Response
 
     expect(res).not.toBeNull()
-    expect(res.headers.get('Set-Cookie')).toBe(formatFrontendCookie(true))
+    expect(res.headers.get('Set-Cookie')).toBe(formatFrontendUsageCookie(true))
     expect(await res.text()).toBe('Enable frontend')
   })
 
@@ -26,12 +26,12 @@ describe('handleRequest()', () => {
     const res = (await handleRequest(new Request(url))) as Response
 
     expect(res).not.toBeNull()
-    expect(res.headers.get('Set-Cookie')).toBe(formatFrontendCookie(false))
+    expect(res.headers.get('Set-Cookie')).toBe(formatFrontendUsageCookie(false))
     expect(await res.text()).toBe('Disable frontend')
   })
 })
 
-test('formatFrontendCookie()', () => {
-  expect(formatFrontendCookie(true)).toBe('useFrontend=true; path=/')
-  expect(formatFrontendCookie(false)).toBe('useFrontend=false; path=/')
+test('formatFrontendUsageCookie()', () => {
+  expect(formatFrontendUsageCookie(true)).toBe('useFrontend=true; path=/')
+  expect(formatFrontendUsageCookie(false)).toBe('useFrontend=false; path=/')
 })

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -192,7 +192,7 @@ async function handleUrl(
   return (await handleRequest(req, probability, TEST_ALLOWED_TYPES)) as Response
 }
 
-function createApiResponse(typename = TEST_ALLOWED_TYPES[0]) {
+export function createApiResponse(typename = TEST_ALLOWED_TYPES[0]) {
   return createJsonResponse({ data: { uuid: { __typename: typename } } })
 }
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -1,0 +1,14 @@
+import { handleRequest } from '../src/frontend-proxy'
+
+describe('handleRequest()', () => {
+  describe('returns null if language tenant is not "de"', () => {
+    test.each([
+      'https://serlo.org/',
+      'http://ta.serlo.org/',
+      'https://stats.serlo.org/',
+      'http://en.serlo.org/math',
+    ])('URL is %p', async (url) => {
+      expect(await handleRequest(new Request(url))).toBeNull()
+    })
+  })
+})

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -135,12 +135,14 @@ describe('handleRequest()', () => {
     expect(await global.FRONTEND_CACHE_TYPES.get('/math')).toBeNull()
   })
 
-  describe('requests to /_next and /_assets always resolve to frontend', () => {
+  describe('requests to /_next, /api/frontend and /_assets always resolve to frontend', () => {
     test.each([
       'https://de.serlo.org/_next/script.js',
       'https://de.serlo.org/_next/img/picture.svg',
       'https://de.serlo.org/_assets/script.js',
       'https://de.serlo.org/_assets/img/picture.svg',
+      'https://de.serlo.org/api/frontend/script.js',
+      'https://de.serlo.org/api/frontend/img/picture.svg',
     ])('URL is %p', async (url) => {
       const mockedFetch = mockFetchReturning('')
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -7,7 +7,7 @@ import { createJsonResponse } from '../src/utils'
 import { withMockedFetch, hasOkStatus } from './utils'
 
 const TEST_ALLOWED_TYPES = ['User', 'Article']
-const testUrl = 'https://de.serlo.org/example-url'
+const testUrl = 'https://de.serlo.org/_nextexample-url'
 
 describe('handleRequest()', () => {
   describe('returns null if language tenant is not "de"', () => {
@@ -59,10 +59,12 @@ describe('handleRequest()', () => {
     })
   })
 
-  describe('requests to /_next always resolve to frontend', () => {
+  describe('requests to /_next and /_assets always resolve to frontend', () => {
     test.each([
       'https://de.serlo.org/_next/script.js',
       'https://de.serlo.org/_next/img/picture.svg',
+      'https://de.serlo.org/_assets/script.js',
+      'https://de.serlo.org/_assets/img/picture.svg',
     ])('URL is %p', async (url) => {
       await withMockedFetch([checkFrontendRequest], async () => {
         const response = await handleUrl(url)

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -185,8 +185,9 @@ describe('handleRequest()', () => {
         global.FRONTEND_PROBABILITY = '1'
         global.FRONTEND_ALLOWED_TYPES = '["User"]'
 
+        // TODO: With with multiple Cookies
         const request = new Request(url, {
-          headers: { Cookie: `useFrontend=${cookieValue};` },
+          headers: { Cookie: `useFrontend=${cookieValue}` },
         })
         const response = (await handleRequest(request))!
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -160,7 +160,7 @@ describe('handleRequest()', () => {
     describe.each([
       ['https://de.serlo.org/math', '0.5'],
       ['https://de.serlo.org/10', '0.00001'],
-      ['https://de.serlo.org/_nextexample-url', '0.9999999'],
+      ['https://de.serlo.org/_nextexample-url', '1'],
     ])('URL=%p Cookie=%p', (url, cookieValue) => {
       test('frontend backend', async () => {
         const mockedFetch = mockFetchReturning(createApiResponse('User'), '')

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -52,10 +52,10 @@ class RequestMock {
 }
 
 beforeAll(() => {
-  process.env.FRONTEND_DOMAIN = 'frontend.domain'
-  process.env.API_ENDPOINT = 'api.endpoint'
-  process.env.FRONTEND_PROBABILITY = '1'
-  process.env.FRONTEND_ALLOWED_TYPES = '[]'
+  global.FRONTEND_DOMAIN = 'frontend.domain'
+  global.API_ENDPOINT = 'api.endpoint'
+  global.FRONTEND_PROBABILITY = '1'
+  global.FRONTEND_ALLOWED_TYPES = '[]'
 })
 
 beforeEach(() => {

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -51,6 +51,13 @@ class RequestMock {
   constructor(public url: string) {}
 }
 
+beforeAll(() => {
+  process.env.FRONTEND_DOMAIN = 'frontend.domain'
+  process.env.API_ENDPOINT = 'api.endpoint'
+  process.env.FRONTEND_PROBABILITY = '1'
+  process.env.FRONTEND_ALLOWED_TYPES = '[]'
+})
+
 beforeEach(() => {
   fetchMock = jest.fn(() => {
     return true
@@ -82,6 +89,7 @@ describe('Enforce HTTPS', () => {
 
   test('HTTPS URL', async () => {
     await handleRequest('https://foo.serlo.local/bar')
+
     expectFetchToHaveBeenCalledWithRequest({
       url: 'https://foo.serlo.local/bar',
     } as Request)
@@ -89,6 +97,7 @@ describe('Enforce HTTPS', () => {
 
   test('Pact Broker', async () => {
     await handleRequest('http://pacts.serlo.local/bar')
+
     expectFetchToHaveBeenCalledWithRequest({
       url: 'http://pacts.serlo.local/bar',
     } as Request)

--- a/__tests__/maintenance.ts
+++ b/__tests__/maintenance.ts
@@ -22,11 +22,11 @@
 import { DateTime } from 'luxon'
 
 import { maintenanceMode } from '../src/maintenance'
-import { contentTypeIsHtml, containsText } from './utils'
+import { contentTypeIsHtml, containsText, mockKV } from './utils'
 
 describe('Maintenance mode', () => {
   test('Disabled (no maintenance planned)', async () => {
-    mockMaintenanceKV({})
+    mockKV('MAINTENANCE_KV', {})
 
     expect(await handleUrl('https://de.serlo.org')).toBeNull()
   })
@@ -37,7 +37,7 @@ describe('Maintenance mode', () => {
       end: DateTime.local().plus({ minutes: 20 }).toISO(),
       subdomains: ['de'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -50,7 +50,7 @@ describe('Maintenance mode', () => {
       end: DateTime.local().minus({ minutes: 10 }).toISO(),
       subdomains: ['de'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -64,7 +64,7 @@ describe('Maintenance mode', () => {
       end: end.toISO(),
       subdomains: ['de'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -85,7 +85,7 @@ describe('Maintenance mode', () => {
       end: end.toISO(),
       subdomains: ['en'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -104,7 +104,7 @@ describe('Maintenance mode', () => {
       start: DateTime.local().minus({ minutes: 10 }).toISO(),
       subdomains: ['de'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -122,7 +122,7 @@ describe('Maintenance mode', () => {
       start: DateTime.local().minus({ minutes: 10 }).toISO(),
       subdomains: ['en'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -142,7 +142,7 @@ describe('Maintenance mode', () => {
       end: end.toISO(),
       subdomains: ['en'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -154,7 +154,7 @@ describe('Maintenance mode', () => {
       start: DateTime.local().minus({ minutes: 10 }).toISO(),
       subdomains: ['en'],
     }
-    mockMaintenanceKV({
+    mockKV('MAINTENANCE_KV', {
       enabled: JSON.stringify(value),
     })
 
@@ -164,15 +164,4 @@ describe('Maintenance mode', () => {
 
 async function handleUrl(url: string): Promise<Response> {
   return (await maintenanceMode(new Request(url))) as Response
-}
-
-function mockMaintenanceKV(values: Record<string, unknown>) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
-  window['MAINTENANCE_KV'] = {
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async get(key: string) {
-      return values[key] || null
-    },
-  }
 }

--- a/__tests__/static-pages.tsx
+++ b/__tests__/static-pages.tsx
@@ -78,7 +78,7 @@ describe('handleRequest()', () => {
       'https://de.serlo.org/imprint',
       'https://fr.serlo.org/imprint/',
     ])('URL is %p', async (url) => {
-      await withMockedFetch('<p>Hello World</p>', async () => {
+      await withMockedFetch(['<p>Hello World</p>'], async () => {
         const response = (await testHandleRequest(url)) as Response
 
         hasOkStatus(response)
@@ -89,7 +89,7 @@ describe('handleRequest()', () => {
   })
 
   test('returns unrevised page response at /terms (markdown specification)', async () => {
-    await withMockedFetch('# Terms of Use', async () => {
+    await withMockedFetch(['# Terms of Use'], async () => {
       const url = 'https://de.serlo.org/terms'
       const response = (await testHandleRequest(url)) as Response
 
@@ -100,7 +100,7 @@ describe('handleRequest()', () => {
   })
 
   test('returns current revision for requests at /privacy', async () => {
-    await withMockedFetch('<p>Hello</p>', async () => {
+    await withMockedFetch(['<p>Hello</p>'], async () => {
       const url = 'https://de.serlo.org/privacy/'
       const response = (await testHandleRequest(url)) as Response
 
@@ -114,7 +114,7 @@ describe('handleRequest()', () => {
   })
 
   test('returns archived revision for requests at /privacy/archive/<id>', async () => {
-    await withMockedFetch('<p>Hello</p>', async () => {
+    await withMockedFetch(['<p>Hello</p>'], async () => {
       const url = 'https://de.serlo.org/privacy/archive/1999-10-09'
       const response = (await testHandleRequest(url)) as Response
 
@@ -282,7 +282,7 @@ describe('fetchContent()', () => {
 
   describe('returns page when url can be resolved', () => {
     test('parses reponse as Markdown if url ends with `.md`', async () => {
-      await withMockedFetch('# Hello World', async () => {
+      await withMockedFetch(['# Hello World'], async () => {
         expect(await fetchContent(exampleSpecMarkdown)).toEqual({
           lang: 'de',
           title: 'Imprint',
@@ -293,7 +293,7 @@ describe('fetchContent()', () => {
     })
 
     test('returns response content when url does not end with `.md`', async () => {
-      await withMockedFetch('<h1>Hello World</h1>', async () => {
+      await withMockedFetch(['<h1>Hello World</h1>'], async () => {
         expect(await fetchContent(exampleSpec)).toEqual({
           lang: 'en',
           title: 'Imprint',
@@ -306,7 +306,7 @@ describe('fetchContent()', () => {
     describe('returned HTML is sanitized', () => {
       test('HTML response', async () => {
         await withMockedFetch(
-          '<h1>Hello World</h1><script>alert(42)</script>',
+          ['<h1>Hello World</h1><script>alert(42)</script>'],
           async () => {
             expect(await fetchContent(exampleSpec)).toEqual({
               lang: 'en',
@@ -320,7 +320,7 @@ describe('fetchContent()', () => {
 
       test('Markdown response', async () => {
         await withMockedFetch(
-          'Hello\n<iframe src="http://serlo.org/">',
+          ['Hello\n<iframe src="http://serlo.org/">'],
           async () => {
             expect(await fetchContent(exampleSpecMarkdown)).toEqual({
               lang: 'de',
@@ -337,7 +337,7 @@ describe('fetchContent()', () => {
   describe('support for __JS_GOOGLE_ANALYTICS_DEACTIVATE__', () => {
     test('HTML response', async () => {
       await withMockedFetch(
-        'Click <a href="__JS_GOOGLE_ANALYTICS_DEACTIVATE__">here</a>',
+        ['Click <a href="__JS_GOOGLE_ANALYTICS_DEACTIVATE__">here</a>'],
         async () => {
           expect(await fetchContent(exampleSpec)).toEqual({
             lang: 'en',
@@ -351,7 +351,7 @@ describe('fetchContent()', () => {
 
     test('Markdown response', async () => {
       await withMockedFetch(
-        'Click [here](__JS_GOOGLE_ANALYTICS_DEACTIVATE__)',
+        ['Click [here](__JS_GOOGLE_ANALYTICS_DEACTIVATE__)'],
         async () => {
           expect(await fetchContent(exampleSpecMarkdown)).toEqual({
             lang: 'de',
@@ -366,7 +366,7 @@ describe('fetchContent()', () => {
 
   describe('returns null when request on the url of the spec fails', () => {
     test.each([301, 404, 500])('status code %p', async (code) => {
-      await withMockedFetch(new Response('', { status: code }), async () => {
+      await withMockedFetch([new Response('', { status: code })], async () => {
         expect(await fetchContent(exampleSpec)).toBeNull()
       })
     })

--- a/__tests__/static-pages.tsx
+++ b/__tests__/static-pages.tsx
@@ -45,7 +45,7 @@ import {
   hasOkStatus,
   containsText,
   contentTypeIsHtml,
-  withMockedFetch,
+  mockFetchReturning,
 } from './utils'
 
 describe('handleRequest()', () => {
@@ -78,50 +78,47 @@ describe('handleRequest()', () => {
       'https://de.serlo.org/imprint',
       'https://fr.serlo.org/imprint/',
     ])('URL is %p', async (url) => {
-      await withMockedFetch(['<p>Hello World</p>'], async () => {
-        const response = (await testHandleRequest(url)) as Response
+      mockFetchReturning('<p>Hello World</p>')
 
-        hasOkStatus(response)
-        contentTypeIsHtml(response)
-        await containsText(response, ['<p>Hello World</p>'])
-      })
+      const response = (await testHandleRequest(url))!
+
+      hasOkStatus(response)
+      contentTypeIsHtml(response)
+      await containsText(response, ['<p>Hello World</p>'])
     })
   })
 
   test('returns unrevised page response at /terms (markdown specification)', async () => {
-    await withMockedFetch(['# Terms of Use'], async () => {
-      const url = 'https://de.serlo.org/terms'
-      const response = (await testHandleRequest(url)) as Response
+    mockFetchReturning('# Terms of Use')
 
-      hasOkStatus(response)
-      contentTypeIsHtml(response)
-      await containsText(response, ['<h1>Terms of Use</h1>'])
-    })
+    const url = 'https://de.serlo.org/terms'
+    const response = (await testHandleRequest(url))!
+
+    hasOkStatus(response)
+    contentTypeIsHtml(response)
+    await containsText(response, ['<h1>Terms of Use</h1>'])
   })
 
   test('returns current revision for requests at /privacy', async () => {
-    await withMockedFetch(['<p>Hello</p>'], async () => {
-      const url = 'https://de.serlo.org/privacy/'
-      const response = (await testHandleRequest(url)) as Response
+    mockFetchReturning('<p>Hello</p>')
 
-      hasOkStatus(response)
-      contentTypeIsHtml(response)
-      await containsText(response, [
-        '<p>Hello</p>',
-        'wirksam ab dem 12/11/2020',
-      ])
-    })
+    const url = 'https://de.serlo.org/privacy/'
+    const response = (await testHandleRequest(url))!
+
+    hasOkStatus(response)
+    contentTypeIsHtml(response)
+    await containsText(response, ['<p>Hello</p>', 'wirksam ab dem 12/11/2020'])
   })
 
   test('returns archived revision for requests at /privacy/archive/<id>', async () => {
-    await withMockedFetch(['<p>Hello</p>'], async () => {
-      const url = 'https://de.serlo.org/privacy/archive/1999-10-09'
-      const response = (await testHandleRequest(url)) as Response
+    mockFetchReturning('<p>Hello</p>')
 
-      hasOkStatus(response)
-      contentTypeIsHtml(response)
-      await containsText(response, ['<p>Hello</p>', 'wirksam ab dem 10/9/1999'])
-    })
+    const url = 'https://de.serlo.org/privacy/archive/1999-10-09'
+    const response = (await testHandleRequest(url)) as Response
+
+    hasOkStatus(response)
+    contentTypeIsHtml(response)
+    await containsText(response, ['<p>Hello</p>', 'wirksam ab dem 10/9/1999'])
   })
 
   test('returns overview of revisions for requests at /privacy/archive', async () => {
@@ -282,18 +279,31 @@ describe('fetchContent()', () => {
 
   describe('returns page when url can be resolved', () => {
     test('parses reponse as Markdown if url ends with `.md`', async () => {
-      await withMockedFetch(['# Hello World'], async () => {
-        expect(await fetchContent(exampleSpecMarkdown)).toEqual({
-          lang: 'de',
-          title: 'Imprint',
-          content: '<h1>Hello World</h1>',
-          url: 'http://example.org/imprint.md',
-        })
+      mockFetchReturning('# Hello World')
+
+      expect(await fetchContent(exampleSpecMarkdown)).toEqual({
+        lang: 'de',
+        title: 'Imprint',
+        content: '<h1>Hello World</h1>',
+        url: 'http://example.org/imprint.md',
       })
     })
 
     test('returns response content when url does not end with `.md`', async () => {
-      await withMockedFetch(['<h1>Hello World</h1>'], async () => {
+      mockFetchReturning('<h1>Hello World</h1>')
+
+      expect(await fetchContent(exampleSpec)).toEqual({
+        lang: 'en',
+        title: 'Imprint',
+        content: '<h1>Hello World</h1>',
+        url: 'http://example.org/',
+      })
+    })
+
+    describe('returned HTML is sanitized', () => {
+      test('HTML response', async () => {
+        mockFetchReturning('<h1>Hello World</h1><script>alert(42)</script>')
+
         expect(await fetchContent(exampleSpec)).toEqual({
           lang: 'en',
           title: 'Imprint',
@@ -301,74 +311,50 @@ describe('fetchContent()', () => {
           url: 'http://example.org/',
         })
       })
-    })
-
-    describe('returned HTML is sanitized', () => {
-      test('HTML response', async () => {
-        await withMockedFetch(
-          ['<h1>Hello World</h1><script>alert(42)</script>'],
-          async () => {
-            expect(await fetchContent(exampleSpec)).toEqual({
-              lang: 'en',
-              title: 'Imprint',
-              content: '<h1>Hello World</h1>',
-              url: 'http://example.org/',
-            })
-          }
-        )
-      })
 
       test('Markdown response', async () => {
-        await withMockedFetch(
-          ['Hello\n<iframe src="http://serlo.org/">'],
-          async () => {
-            expect(await fetchContent(exampleSpecMarkdown)).toEqual({
-              lang: 'de',
-              title: 'Imprint',
-              content: '<p>Hello</p>',
-              url: 'http://example.org/imprint.md',
-            })
-          }
-        )
+        mockFetchReturning('Hello\n<iframe src="http://serlo.org/">')
+
+        expect(await fetchContent(exampleSpecMarkdown)).toEqual({
+          lang: 'de',
+          title: 'Imprint',
+          content: '<p>Hello</p>',
+          url: 'http://example.org/imprint.md',
+        })
       })
     })
   })
 
   describe('support for __JS_GOOGLE_ANALYTICS_DEACTIVATE__', () => {
     test('HTML response', async () => {
-      await withMockedFetch(
-        ['Click <a href="__JS_GOOGLE_ANALYTICS_DEACTIVATE__">here</a>'],
-        async () => {
-          expect(await fetchContent(exampleSpec)).toEqual({
-            lang: 'en',
-            title: 'Imprint',
-            content: 'Click <a href="javascript:gaOptout();">here</a>',
-            url: 'http://example.org/',
-          })
-        }
-      )
+      const text = 'Click <a href="__JS_GOOGLE_ANALYTICS_DEACTIVATE__">here</a>'
+      mockFetchReturning(text)
+
+      expect(await fetchContent(exampleSpec)).toEqual({
+        lang: 'en',
+        title: 'Imprint',
+        content: 'Click <a href="javascript:gaOptout();">here</a>',
+        url: 'http://example.org/',
+      })
     })
 
     test('Markdown response', async () => {
-      await withMockedFetch(
-        ['Click [here](__JS_GOOGLE_ANALYTICS_DEACTIVATE__)'],
-        async () => {
-          expect(await fetchContent(exampleSpecMarkdown)).toEqual({
-            lang: 'de',
-            title: 'Imprint',
-            content: '<p>Click <a href="javascript:gaOptout();">here</a></p>',
-            url: 'http://example.org/imprint.md',
-          })
-        }
-      )
+      mockFetchReturning('Click [here](__JS_GOOGLE_ANALYTICS_DEACTIVATE__)')
+
+      expect(await fetchContent(exampleSpecMarkdown)).toEqual({
+        lang: 'de',
+        title: 'Imprint',
+        content: '<p>Click <a href="javascript:gaOptout();">here</a></p>',
+        url: 'http://example.org/imprint.md',
+      })
     })
   })
 
   describe('returns null when request on the url of the spec fails', () => {
     test.each([301, 404, 500])('status code %p', async (code) => {
-      await withMockedFetch([new Response('', { status: code })], async () => {
-        expect(await fetchContent(exampleSpec)).toBeNull()
-      })
+      mockFetchReturning(new Response('', { status: code }))
+
+      expect(await fetchContent(exampleSpec)).toBeNull()
     })
   })
 })

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -164,7 +164,7 @@ function convertToResponse(spec: string | Response): Response {
 export function mockKV(name: string, values: Record<string, unknown>) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
-  window[name] = {
+  global[name] = {
     // eslint-disable-next-line @typescript-eslint/require-await
     async get(key: string) {
       return values[key] ?? null

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -160,3 +160,19 @@ export function mockFetchReturning(...responseSpecs: Array<string | Response>) {
 function convertToResponse(spec: string | Response): Response {
   return typeof spec === 'string' ? new Response(spec) : spec
 }
+
+export function mockKV(name: string, values: Record<string, unknown>) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  window[name] = {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async get(key: string) {
+      return values[key] ?? null
+    },
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async put(key: string, value: unknown, _?: { expirationTtl: number }) {
+      values[key] = value
+    },
+  }
+}

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -152,7 +152,7 @@ export async function withMockedFetch(
     if (mockImplSpec instanceof Response) return mockImplSpec
 
     const request = typeof reqInfo === 'string' ? new Request(reqInfo) : reqInfo
-    return await mockImplSpec(request)
+    return mockImplSpec(request)
   }
 
   const fetch = jest.fn().mockImplementationOnce(mockedFetch)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -23,6 +23,14 @@
 import '@testing-library/jest-dom'
 import { Response, Request } from 'node-fetch'
 
+const fetchCopy = global.fetch
+const randomCopy = Math.random
+
+afterEach(() => {
+  Math.random = randomCopy
+  global.fetch = fetchCopy
+})
+
 global.Response = Response
 global.Request = Request
 

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -9,10 +9,12 @@ export async function handleRequest(
 
   const path = getPathname(url)
 
-  if (path === "/enable-frontend") {
-    const response = new Response("Enable frontend")
-    response.headers.set("Set-Cookie", formatFrontendCookie(true))
-    return response
+  if (path === '/enable-frontend') {
+    return createFrontendUsageResponse('Enable frontend', true)
+  }
+
+  if (path === '/disable-frontend') {
+    return createFrontendUsageResponse('Disable frontend', false)
   }
 
   return new Response('')
@@ -20,4 +22,12 @@ export async function handleRequest(
 
 export function formatFrontendCookie(useFrontend: boolean) {
   return `useFrontend=${useFrontend}; path=/`
+}
+
+function createFrontendUsageResponse(body: string, useFrontend: boolean) {
+  const response = new Response(body)
+
+  response.headers.set('Set-Cookie', formatFrontendCookie(useFrontend))
+
+  return response
 }

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,5 +1,7 @@
 import { getSubdomain, getPathname } from './url-utils'
 
+export const FRONTEND_DOMAIN = 'frontend-sooty-ten.now.sh'
+
 export async function handleRequest(
   request: Request
 ): Promise<Response | null> {
@@ -15,6 +17,14 @@ export async function handleRequest(
 
   if (path === '/disable-frontend') {
     return createFrontendUsageResponse('Disable frontend', false)
+  }
+
+  if (path.startsWith('/_next')) {
+    const frontendUrl = `https://${FRONTEND_DOMAIN}${path}`
+    const frontendResponse = await fetch(frontendUrl)
+
+    const response = new Response(frontendResponse.body)
+    return response
   }
 
   return new Response('')

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,6 +1,6 @@
 import { getSubdomain, getPathname } from './url-utils'
 
-export const FRONTEND_DOMAIN = 'frontend-sooty-ten.now.sh'
+export const FRONTEND_DOMAIN = 'frontend.serlo.now.sh'
 const API_ENDPOINT = 'https://api.serlo.org/graphql'
 const FRONTEND_ALLOWED_TYPES = [
   'Article',

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -21,7 +21,7 @@ export async function handleRequest(
 
   const { useFrontend } = chooseBackend(request)
   const backendRequest = useFrontend
-    ? new Request(`https://${FRONTEND_DOMAIN}${path}`)
+    ? new Request(`https://${FRONTEND_DOMAIN}${path}`, request)
     : request
 
   return await fetch(backendRequest)

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -20,14 +20,14 @@ export async function handleRequest(
   return new Response('')
 }
 
-export function formatFrontendCookie(useFrontend: boolean) {
+export function formatFrontendUsageCookie(useFrontend: boolean) {
   return `useFrontend=${useFrontend}; path=/`
 }
 
 function createFrontendUsageResponse(body: string, useFrontend: boolean) {
   const response = new Response(body)
 
-  response.headers.set('Set-Cookie', formatFrontendCookie(useFrontend))
+  response.headers.set('Set-Cookie', formatFrontendUsageCookie(useFrontend))
 
   return response
 }

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -56,16 +56,18 @@ export async function handleRequest(
     useFrontend: boolean
     setCookie: boolean
   }) {
-    const frontendUrl = `https://${frontendDomain}${getPathname(request.url)}`
-    const backendRequest = useFrontend
-      ? new Request(frontendUrl, request)
-      : request.clone()
-    backendRequest.headers.set('X-SERLO-API', apiEndpoint)
+    const backendUrl = useFrontend
+      ? `https://${global.FRONTEND_DOMAIN}${getPathname(request.url)}`
+      : request.url
+    const backendRequest = new Request(backendUrl, request)
+    backendRequest.headers.set('X-SERLO-API', global.API_ENDPOINT)
 
-    const response = (await fetch(backendRequest)).clone()
-    if (setCookie) setCookieUseFrontend(response, useFrontend)
+    const response = await fetch(backendRequest)
 
-    return response
+    const clonedResponse = new Response(response.body, response)
+    if (setCookie) setCookieUseFrontend(clonedResponse, useFrontend)
+
+    return clonedResponse
   }
 
   function setCookieUseFrontend(res: Response, useFrontend: boolean) {

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -56,7 +56,7 @@ export async function handleRequest(
     setCookie: boolean
   }) {
     const backendUrl =
-      useFrontend < probability
+      useFrontend <= probability
         ? `https://${global.FRONTEND_DOMAIN}${getPathname(request.url)}`
         : request.url
     const backendRequest = new Request(backendUrl, request)

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -71,7 +71,7 @@ export async function handleRequest(
   }
 
   function setCookieUseFrontend(res: Response, useFrontend: boolean) {
-    res.headers.set('Set-Cookie', `${formatCookie(useFrontend)}; path=/`)
+    res.headers.append('Set-Cookie', `${formatCookie(useFrontend)}; path=/`)
   }
 
   function formatCookie(useFrontend: boolean) {

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -31,8 +31,10 @@ export async function handleRequest(
   if (path.startsWith('/_next/') || path.startsWith('/_assets/'))
     return await fetchBackend(true, false)
 
-  const typename = await queryTypename(path)
-  if (typename === null || !allowedTypes.includes(typename)) return null
+  if (path !== '/') {
+    const typename = await queryTypename(path)
+    if (typename === null || !allowedTypes.includes(typename)) return null
+  }
 
   const cookies = request.headers.get('Cookie')
 

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -43,14 +43,15 @@ export async function handleRequest(
     if (typename === null || !allowedTypes.includes(typename)) return null
   }
 
-  const cookieUseFrontend = cookies?.match(/useFrontend=(\d(\.\d+)?)/)
-  const useFrontendNumber = cookieUseFrontend
-    ? Number(cookieUseFrontend[1])
-    : Math.random()
-  const setCookie = !cookieUseFrontend
+  const cookieUseFrontend = cookies?.match(/useFrontend=([^;]+)/)?.[1]
+  const convertedCookieValue = Number(cookieUseFrontend)
+  const useFrontendNumber = Number.isNaN(convertedCookieValue)
+    ? Math.random()
+    : convertedCookieValue
 
   const response = await fetchBackend(useFrontendNumber <= probability)
-  if (setCookie) setCookieUseFrontend(response, useFrontendNumber)
+  if (Number.isNaN(convertedCookieValue))
+    setCookieUseFrontend(response, useFrontendNumber)
 
   return response
 

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -43,7 +43,7 @@ export async function handleRequest(
     if (typename === null || !allowedTypes.includes(typename)) return null
   }
 
-  const cookieUseFrontend = cookies?.match(/useFrontend=(\d(\.\d+)?);/)
+  const cookieUseFrontend = cookies?.match(/useFrontend=(\d(\.\d+)?)/)
   const useFrontendNumber = cookieUseFrontend
     ? Number(cookieUseFrontend[1])
     : Math.random()

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -8,7 +8,7 @@ const FRONTEND_PROBABILITY = 0.1
 export async function handleRequest(
   request: Request,
   probability = FRONTEND_PROBABILITY,
-  allowdTypes = FRONTEND_ALLOWED_TYPES
+  allowedTypes = FRONTEND_ALLOWED_TYPES
 ): Promise<Response | null> {
   const url = request.url
   const path = getPathname(url)
@@ -23,7 +23,7 @@ export async function handleRequest(
   if (path.startsWith('/_next')) return await fetchBackend(true, false)
 
   const typename = await queryTypename(path)
-  if (typename === null || !allowdTypes.includes(typename)) return null
+  if (typename === null || !allowedTypes.includes(typename)) return null
 
   const cookies = request.headers.get('Cookie')
 

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -7,3 +7,7 @@ export async function handleRequest(
 
   return new Response('')
 }
+
+export function formatFrontendCookie(useFrontend: boolean) {
+  return `useFrontend=${useFrontend}; path=/`
+}

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,9 +1,19 @@
-import { getSubdomain } from './url-utils'
+import { getSubdomain, getPathname } from './url-utils'
 
 export async function handleRequest(
   request: Request
 ): Promise<Response | null> {
-  if (getSubdomain(request.url) !== 'de') return null
+  const url = request.url
+
+  if (getSubdomain(url) !== 'de') return null
+
+  const path = getPathname(url)
+
+  if (path === "/enable-frontend") {
+    const response = new Response("Enable frontend")
+    response.headers.set("Set-Cookie", formatFrontendCookie(true))
+    return response
+  }
 
   return new Response('')
 }

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,23 +1,15 @@
 import { getSubdomain, getPathname } from './url-utils'
 
-export const FRONTEND_DOMAIN = 'frontend.serlo.now.sh'
-const API_ENDPOINT = 'https://api.serlo.org/graphql'
-const FRONTEND_ALLOWED_TYPES = [
-  'Article',
-  'Applet',
-  'Course',
-  'CoursePage',
-  'Page',
-  'TaxonomyTerm',
-  'Video',
-]
-const FRONTEND_PROBABILITY = 0.1
-
 export async function handleRequest(
-  request: Request,
-  probability = FRONTEND_PROBABILITY,
-  allowedTypes = FRONTEND_ALLOWED_TYPES
+  request: Request
 ): Promise<Response | null> {
+  const frontendDomain = getEnvironmentVariable('FRONTEND_DOMAIN')
+  const apiEndpoint = getEnvironmentVariable('API_ENDPOINT')
+  const probability = Number(getEnvironmentVariable('FRONTEND_PROBABILITY'))
+  const allowedTypes = JSON.parse(
+    getEnvironmentVariable('FRONTEND_ALLOWED_TYPES')
+  )
+
   const url = request.url
   const path = getPathname(url)
 
@@ -26,7 +18,7 @@ export async function handleRequest(
   if (path === '/enable-frontend') {
     const response = new Response('Enable frontend')
 
-    setFrontendUseCookie(response, true)
+    setCookieUseFrontend(response, true)
 
     return response
   }
@@ -34,7 +26,7 @@ export async function handleRequest(
   if (path === '/disable-frontend') {
     const response = new Response('Disable frontend')
 
-    setFrontendUseCookie(response, false)
+    setCookieUseFrontend(response, false)
 
     return response
   }
@@ -66,36 +58,36 @@ export async function handleRequest(
     useFrontend: boolean
     setCookie: boolean
   }) {
-    const frontendUrl = `https://${FRONTEND_DOMAIN}${getPathname(request.url)}`
+    const frontendUrl = `https://${frontendDomain}${getPathname(request.url)}`
     const backendRequest = useFrontend
       ? new Request(frontendUrl, request)
       : request
     const response = (await fetch(backendRequest)).clone()
 
-    if (setCookie) setFrontendUseCookie(response, useFrontend)
+    if (setCookie) setCookieUseFrontend(response, useFrontend)
 
     return response
   }
 
-  function setFrontendUseCookie(res: Response, useFrontend: boolean) {
+  function setCookieUseFrontend(res: Response, useFrontend: boolean) {
     res.headers.set('Set-Cookie', `${formatCookie(useFrontend)}; path=/`)
   }
 
   function formatCookie(useFrontend: boolean) {
     return `useFrontend${Math.floor(probability * 100)}=${useFrontend}`
   }
-}
 
-async function queryTypename(path: string): Promise<string | null> {
-  const apiRequest = new Request(API_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query: createApiQuery(path) }),
-  })
-  const apiResponse = await fetch(apiRequest)
-  const apiResult = await apiResponse.json()
+  async function queryTypename(path: string): Promise<string | null> {
+    const apiRequest = new Request(apiEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: createApiQuery(path) }),
+    })
+    const apiResponse = await fetch(apiRequest)
+    const apiResult = await apiResponse.json()
 
-  return apiResult?.data?.uuid?.__typename ?? null
+    return apiResult?.data?.uuid?.__typename ?? null
+  }
 }
 
 export function createApiQuery(path: string): string {
@@ -105,4 +97,12 @@ export function createApiQuery(path: string): string {
     : `alias: { instance: de, path: "/${pathWithoutSlash}" }`
 
   return `{ uuid(${query}) { __typename } }`
+}
+
+function getEnvironmentVariable(envName: string): string {
+  const value = process.env[envName]
+
+  if (value === undefined) throw new TypeError(`${envName} is not set`)
+
+  return value
 }

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,57 +1,84 @@
 import { getSubdomain, getPathname } from './url-utils'
 
 export const FRONTEND_DOMAIN = 'frontend-sooty-ten.now.sh'
+const API_ENDPOINT = 'https://api.serlo.org/graphql'
+const FRONTEND_ALLOWED_TYPES = ['Article', 'TaxonomyTerm']
 const FRONTEND_PROBABILITY = 0.1
 
 export async function handleRequest(
   request: Request,
-  probability = FRONTEND_PROBABILITY
+  probability = FRONTEND_PROBABILITY,
+  allowdTypes = FRONTEND_ALLOWED_TYPES
 ): Promise<Response | null> {
   const url = request.url
   const path = getPathname(url)
 
   if (getSubdomain(url) !== 'de') return null
+
   if (path === '/enable-frontend')
     return createResponse('Enable frontend', probability, true)
   if (path === '/disable-frontend')
     return createResponse('Disable frontend', probability, false)
 
-  const { useFrontend, setCookie } = chooseBackend(request, probability)
+  if (path.startsWith('/_next')) return await fetchBackend(true, false)
 
-  const backendRequest = useFrontend
-    ? new Request(`https://${FRONTEND_DOMAIN}${path}`, request)
-    : request
+  const typename = await queryTypename(path)
+  if (typename === null || !allowdTypes.includes(typename)) return null
 
-  return createResponse(
-    await fetch(backendRequest),
-    probability,
-    setCookie ? useFrontend : undefined
-  )
-}
-
-function chooseBackend(
-  req: Request,
-  probability: number
-): { useFrontend: boolean; setCookie: boolean } {
-  const path = getPathname(req.url)
-  const cookies = req.headers.get('Cookie')
-
-  if (path.startsWith('/_next')) return { useFrontend: true, setCookie: false }
+  const cookies = request.headers.get('Cookie')
 
   if (cookies?.includes(formatCookie(true, probability)))
-    return { useFrontend: true, setCookie: false }
+    return fetchBackend(true, false)
   if (cookies?.includes(formatCookie(false, probability)))
-    return { useFrontend: false, setCookie: false }
+    return await fetchBackend(false, false)
 
-  return { useFrontend: Math.random() < probability, setCookie: true }
+  return await fetchBackend(Math.random() < probability, true)
+
+  async function fetchBackend(useFrontend: boolean, setCookie?: boolean) {
+    const backendRequest = useFrontend
+      ? new Request(
+          `https://${FRONTEND_DOMAIN}${getPathname(request.url)}`,
+          request
+        )
+      : request
+
+    return await createResponse(
+      await fetch(backendRequest),
+      probability,
+      setCookie ? useFrontend : undefined
+    )
+  }
 }
 
-function createResponse(
-  text: string | Response,
+async function queryTypename(path: string): Promise<string | null> {
+  const apiRequest = new Request(API_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: createApiQuery(path) }),
+  })
+  const apiResponse = await fetch(apiRequest)
+  const apiResult = await apiResponse.json()
+
+  return apiResult?.data?.uuid?.__typename ?? null
+}
+
+export function createApiQuery(path: string): string {
+  const pathWithoutSlash = path.startsWith('/') ? path.slice(1) : path
+  const query = /^\/?\d+$/.test(pathWithoutSlash)
+    ? `id: ${pathWithoutSlash}`
+    : `alias: { instance: de, path: "/${pathWithoutSlash}" }`
+
+  return `{ uuid(${query}) { __typename } }`
+}
+
+async function createResponse(
+  resInfo: string | Response,
   probability: number,
   futureFrontendUse?: boolean
 ) {
-  const response = typeof text === 'string' ? new Response(text) : text
+  const body = typeof resInfo === 'string' ? resInfo : await resInfo.text()
+  const init = typeof resInfo === 'string' ? undefined : resInfo
+  const response = new Response(body, init)
 
   if (futureFrontendUse !== undefined) {
     const cookie = `${formatCookie(futureFrontendUse, probability)}; path=/`

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -27,7 +27,11 @@ export async function handleRequest(
     return response
   }
 
-  if (path.startsWith('/_next/') || path.startsWith('/_assets/'))
+  if (
+    path.startsWith('/_next/') ||
+    path.startsWith('/_assets/') ||
+    path.startsWith('/api/frontend/')
+  )
     return await fetchBackend({ useFrontend: 0, setCookie: false })
 
   if (path !== '/') {

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -61,9 +61,10 @@ export async function handleRequest(
     const frontendUrl = `https://${frontendDomain}${getPathname(request.url)}`
     const backendRequest = useFrontend
       ? new Request(frontendUrl, request)
-      : request
-    const response = (await fetch(backendRequest)).clone()
+      : request.clone()
+    backendRequest.headers.set('X-SERLO-API', apiEndpoint)
 
+    const response = (await fetch(backendRequest)).clone()
     if (setCookie) setCookieUseFrontend(response, useFrontend)
 
     return response

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -92,10 +92,9 @@ export async function handleRequest(
 }
 
 export function createApiQuery(path: string): string {
-  const pathWithoutSlash = path.startsWith('/') ? path.slice(1) : path
-  const query = /^\/?\d+$/.test(pathWithoutSlash)
-    ? `id: ${pathWithoutSlash}`
-    : `alias: { instance: de, path: "/${pathWithoutSlash}" }`
+  const query = /^\/\d+$/.test(path)
+    ? `id: ${path.slice(1)}`
+    : `alias: { instance: de, path: "${path}" }`
 
   return `{ uuid(${query}) { __typename } }`
 }

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -20,7 +20,8 @@ export async function handleRequest(
   if (path === '/disable-frontend')
     return createResponse('Disable frontend', probability, false)
 
-  if (path.startsWith('/_next')) return await fetchBackend(true, false)
+  if (path.startsWith('/_next/') || path.startsWith('/_assets/'))
+    return await fetchBackend(true, false)
 
   const typename = await queryTypename(path)
   if (typename === null || !allowedTypes.includes(typename)) return null

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -2,7 +2,15 @@ import { getSubdomain, getPathname } from './url-utils'
 
 export const FRONTEND_DOMAIN = 'frontend-sooty-ten.now.sh'
 const API_ENDPOINT = 'https://api.serlo.org/graphql'
-const FRONTEND_ALLOWED_TYPES = ['Article', 'TaxonomyTerm']
+const FRONTEND_ALLOWED_TYPES = [
+  'Article',
+  'Applet',
+  'Course',
+  'CoursePage',
+  'Page',
+  'TaxonomyTerm',
+  'Video',
+]
 const FRONTEND_PROBABILITY = 0.1
 
 export async function handleRequest(

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,0 +1,9 @@
+import { getSubdomain } from './url-utils'
+
+export async function handleRequest(
+  request: Request
+): Promise<Response | null> {
+  if (getSubdomain(request.url) !== 'de') return null
+
+  return new Response('')
+}

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -71,7 +71,7 @@ export async function handleRequest(
   }
 
   async function queryTypename(path: string): Promise<string | null> {
-    const cachedType = await global.FRONTEND_CACHE_TYPES.get(path)
+    const cachedType = await global.FRONTEND_CACHE_TYPES_KV.get(path)
     if (cachedType !== null) return cachedType
 
     const apiResponse = await fetch(global.API_ENDPOINT, {
@@ -83,7 +83,7 @@ export async function handleRequest(
     const typename = apiResult?.data?.uuid?.__typename ?? null
 
     if (typename !== null)
-      await global.FRONTEND_CACHE_TYPES.put(path, typename, {
+      await global.FRONTEND_CACHE_TYPES_KV.put(path, typename, {
         expirationTtl: 60 * 60,
       })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@
  */
 import { api } from './api'
 import { edtrIoStats } from './are-we-edtr-io-yet'
+import { handleRequest as frontendProxy } from './frontend-proxy'
 import { maintenanceMode } from './maintenance'
 import { handleRequest as staticPages } from './static-pages'
 import { getPathnameWithoutTrailingSlash, getSubdomain } from './url-utils'
@@ -40,6 +41,7 @@ export async function handleRequest(request: Request) {
     (await semanticFileNames(request)) ||
     (await packages(request)) ||
     (await api(request)) ||
+    (await frontendProxy(request)) ||
     (await fetch(request))
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ async function packages(request: Request) {
 
   const pkg = match[1]
 
-  const resolvedPackage = await PACKAGES_KV.get(pkg)
+  const resolvedPackage = await global.PACKAGES_KV.get(pkg)
   if (!resolvedPackage) return fetch(url.href, request)
 
   url.pathname = url.pathname.replace(`/${pkg}/`, `/${resolvedPackage}/`)

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -19,9 +19,19 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
-declare const MAINTENANCE_KV: {
-  get(key: 'enabled'): Promise<string | null>
+declare namespace NodeJS {
+  interface Global {
+    MAINTENANCE_KV: KV<'enabled'>
+    PACKAGES_KV: KV<string>
+    FRONTEND_CACHE_TYPES_KV: KV<string>
+  }
 }
-declare const PACKAGES_KV: {
-  get(key: string): Promise<string | null>
+
+declare interface KV<Keys extends string> {
+  get: (key: string) => Promise<string | null>
+  put: (
+    key: string,
+    value: string,
+    options?: { expirationTtl: number }
+  ) => Promise<void>
 }

--- a/src/maintenance/index.tsx
+++ b/src/maintenance/index.tsx
@@ -27,7 +27,7 @@ import { createPreactResponse } from '../utils'
 import { Maintenance } from './template'
 
 export async function maintenanceMode(request: Request) {
-  const enabled = await MAINTENANCE_KV.get('enabled')
+  const enabled = await global.MAINTENANCE_KV.get('enabled')
   if (!enabled) return null
   const { start: startISO, end: endISO, subdomains = [] } = JSON.parse(enabled)
   if (!subdomains.includes(getSubdomain(request.url))) return null

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -52,7 +52,7 @@ export function markdownToHtml(markdown: string): string {
 }
 
 export async function fetchWithCache(
-  url: string,
+  url: string | Request,
   init?: RequestInit
 ): Promise<Response> {
   return await fetch(url, ({

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -62,9 +62,9 @@ export async function fetchWithCache(
 }
 
 export function getBasicAuthHeaders(): Record<string, string> {
-  if (ENABLE_BASIC_AUTH !== 'true') return {}
-
-  return { Authorization: 'Basic c2VybG90ZWFtOnNlcmxvdGVhbQ==' }
+  return global.ENABLE_BASIC_AUTH === 'true'
+    ? { Authorization: 'Basic c2VybG90ZWFtOnNlcmxvdGVhbQ==' }
+    : {}
 }
 
 export function createPreactResponse(component: VNode, opt?: ResponseInit) {

--- a/src/vars.d.ts
+++ b/src/vars.d.ts
@@ -19,5 +19,15 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
+interface KV<ValueType> {
+  get: (key: string) => Promise<ValueType | null>
+  put: (
+    key: string,
+    value: ValueType,
+    options?: { expirationTtl: number }
+  ) => Promise<void>
+}
+
 declare let DOMAIN: string
 declare let ENABLE_BASIC_AUTH: 'true' | 'false'
+declare const FRONTEND_CACHE_TYPES: KV<string>

--- a/src/vars.d.ts
+++ b/src/vars.d.ts
@@ -27,5 +27,6 @@ declare namespace NodeJS {
     FRONTEND_ALLOWED_TYPES: string
     FRONTEND_DOMAIN: string
     FRONTEND_PROBABILITY: string
+    fetch: typeof fetch
   }
 }

--- a/src/vars.d.ts
+++ b/src/vars.d.ts
@@ -25,18 +25,7 @@ declare namespace NodeJS {
     DOMAIN: string
     ENABLE_BASIC_AUTH: 'true' | 'false'
     FRONTEND_ALLOWED_TYPES: string
-    FRONTEND_CACHE_TYPES: KV<string>
     FRONTEND_DOMAIN: string
     FRONTEND_PROBABILITY: string
   }
-}
-
-declare
-interface KV<ValueType> {
-  get: (key: string) => Promise<ValueType | null>
-  put: (
-    key: string,
-    value: ValueType,
-    options?: { expirationTtl: number }
-  ) => Promise<void>
 }

--- a/src/vars.d.ts
+++ b/src/vars.d.ts
@@ -19,6 +19,19 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
+declare namespace NodeJS {
+  interface Global {
+    API_ENDPOINT: string
+    DOMAIN: string
+    ENABLE_BASIC_AUTH: 'true' | 'false'
+    FRONTEND_ALLOWED_TYPES: string
+    FRONTEND_CACHE_TYPES: KV<string>
+    FRONTEND_DOMAIN: string
+    FRONTEND_PROBABILITY: string
+  }
+}
+
+declare
 interface KV<ValueType> {
   get: (key: string) => Promise<ValueType | null>
   put: (
@@ -27,7 +40,3 @@ interface KV<ValueType> {
     options?: { expirationTtl: number }
   ) => Promise<void>
 }
-
-declare let DOMAIN: string
-declare let ENABLE_BASIC_AUTH: 'true' | 'false'
-declare const FRONTEND_CACHE_TYPES: KV<string>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -53,5 +53,5 @@ API_ENDPOINT = "https://api.serlo.org/graphql"
 DOMAIN = "serlo.org"
 ENABLE_BASIC_AUTH = "false"
 FRONTEND_DOMAIN = "frontend.serlo.now.sh"
-FRONTEND_PROBABILITY = "0.10"
+FRONTEND_PROBABILITY = "0"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,7 +13,7 @@ kv-namespaces = [
 ]
 
 [env.dev.vars]
-API_ENDPOINT = "https://api.serlo.org/graphql"
+API_ENDPOINT = "https://api.serlo-development.dev/graphql"
 DOMAIN = "serlo-development.dev"
 FRONTEND_DOMAIN = "frontend.serlo.now.sh"
 FRONTEND_PROBABILITY = "0.50"
@@ -31,7 +31,7 @@ kv-namespaces = [
 ]
 
 [env.staging.vars]
-API_ENDPOINT = "https://api.serlo.org/graphql"
+API_ENDPOINT = "https://api.serlo-staging.dev/graphql"
 DOMAIN = "serlo-staging.dev"
 FRONTEND_DOMAIN = "frontend.serlo.now.sh"
 FRONTEND_PROBABILITY = "0.50"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,7 +10,14 @@ kv-namespaces = [
     { binding = "MAINTENANCE_KV", id = "d5f281b897f643b8824881cfe2a24dd2" },
     { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
 ]
-vars = { DOMAIN = "serlo-development.dev", ENABLE_BASIC_AUTH = "true" }
+
+[env.dev.vars]
+API_ENDPOINT = "https://api.serlo.org/graphql"
+DOMAIN = "serlo-development.dev"
+FRONTEND_DOMAIN = "frontend.serlo.now.sh"
+FRONTEND_PROBABILITY = "0.50"
+FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
+ENABLE_BASIC_AUTH = "true"
 
 [env.staging]
 name = "serlo-staging"
@@ -20,7 +27,14 @@ kv-namespaces = [
     { binding = "MAINTENANCE_KV", id = "3c3c25aba0b94b7e99f855f013f5b09c" },
     { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
 ]
-vars = { DOMAIN = "serlo-staging.dev", ENABLE_BASIC_AUTH = "true" }
+
+[env.staging.vars]
+API_ENDPOINT = "https://api.serlo.org/graphql"
+DOMAIN = "serlo-staging.dev"
+FRONTEND_DOMAIN = "frontend.serlo.now.sh"
+FRONTEND_PROBABILITY = "0.50"
+FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
+ENABLE_BASIC_AUTH = "true"
 
 [env.production]
 name = "serlo-production"
@@ -30,4 +44,11 @@ kv-namespaces = [
     { binding = "MAINTENANCE_KV", id = "b1f17ebbe39c4fd9b49d1368ce225faa" },
     { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
 ]
-vars = { DOMAIN = "serlo.org", ENABLE_BASIC_AUTH = "false" }
+
+[env.production.vars]
+API_ENDPOINT = "https://api.serlo.org/graphql"
+DOMAIN = "serlo.org"
+ENABLE_BASIC_AUTH = "false"
+FRONTEND_DOMAIN = "frontend.serlo.now.sh"
+FRONTEND_PROBABILITY = "0.10"
+FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,7 @@ route = "*serlo-development.dev/*"
 kv-namespaces = [
     { binding = "MAINTENANCE_KV", id = "d5f281b897f643b8824881cfe2a24dd2" },
     { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
+    { binding = "FRONTEND_CACHE_TYPES", id="802462c937f24f268bb523fa855ee4a1" },
 ]
 
 [env.dev.vars]
@@ -26,6 +27,7 @@ route = "*serlo-staging.dev/*"
 kv-namespaces = [
     { binding = "MAINTENANCE_KV", id = "3c3c25aba0b94b7e99f855f013f5b09c" },
     { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
+    { binding = "FRONTEND_CACHE_TYPES", id="a323aa5ec11a4940abe7fb5ab5d95a39" },
 ]
 
 [env.staging.vars]
@@ -43,6 +45,7 @@ route = "*serlo.org/*"
 kv-namespaces = [
     { binding = "MAINTENANCE_KV", id = "b1f17ebbe39c4fd9b49d1368ce225faa" },
     { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
+    { binding = "FRONTEND_CACHE_TYPES", id="fc4c18a77146456884675bd2776a8102" },
 ]
 
 [env.production.vars]


### PR DESCRIPTION
Fixes https://github.com/serlo/frontend/issues/78

- [x] Fix Search
- [x] cache API responses with KV store
- [x] move constants to environment variables
- [x] API-ENDPOINT als Header weitergeben
- [x] Use Cookie to check route 
- [x] CookieName depends on probability
- [x] Check for entity types to decide which backend should be used
- [x] transfer response and request status code
- [x] setting of cookie (based on probability)
- [x] random decision where to go
- [x] Add route `enable-frontend` and `disable-frontend`
- [x] Prefix `_next` goes to frontend