### PR TITLE
Update frontend proxy

### DIFF
--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -239,6 +239,21 @@ describe('handleRequest()', () => {
       expect(await getCachedType(getPathname(url))).toBeNull()
     })
 
+    test('requests to /search always resolve to frontend', async () => {
+      const url = 'https://de.serlo.org/search'
+      const mockedFetch = mockFetch({
+        'https://frontend.serlo.org/search': '',
+      })
+
+      const response = (await handleRequest(new Request(url)))!
+
+      const targetUrl = url.replace('de.serlo.org', 'frontend.serlo.org')
+      expect(getBackendUrl(mockedFetch)).toBe(targetUrl)
+      expect(getHeaderApiEndpoint(mockedFetch)).toBe('https://api.serlo.org/')
+      expect(response.headers.get('Set-Cookie')).toBeNull()
+      expect(await getCachedType(getPathname(url))).toBeNull()
+    })
+
     describe('special paths need to have a trailing slash in their prefix', () => {
       test.each([
         'https://de.serlo.org/api/frontend-alternative',

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -254,6 +254,21 @@ describe('handleRequest()', () => {
       expect(await getCachedType(getPathname(url))).toBeNull()
     })
 
+    test('requests to /spenden always resolve to frontend', async () => {
+      const url = 'https://de.serlo.org/spenden'
+      const mockedFetch = mockFetch({
+        'https://frontend.serlo.org/spenden': '',
+      })
+
+      const response = (await handleRequest(new Request(url)))!
+
+      const targetUrl = url.replace('de.serlo.org', 'frontend.serlo.org')
+      expect(getBackendUrl(mockedFetch)).toBe(targetUrl)
+      expect(getHeaderApiEndpoint(mockedFetch)).toBe('https://api.serlo.org/')
+      expect(response.headers.get('Set-Cookie')).toBeNull()
+      expect(await getCachedType(getPathname(url))).toBeNull()
+    })
+
     describe('special paths need to have a trailing slash in their prefix', () => {
       test.each([
         'https://de.serlo.org/api/frontend-alternative',
@@ -273,18 +288,6 @@ describe('handleRequest()', () => {
         expect(getBackendUrl(mockedFetch)).toBe(url)
         expect(await getCachedType(getPathname(url))).toBe('Article')
       })
-    })
-
-    test('requests to /spenden always resolve to default backend', async () => {
-      const url = 'https://de.serlo.org/spenden'
-      const mockedFetch = mockFetch({
-        'https://de.serlo.org/spenden': '',
-      })
-
-      await handleRequest(new Request(url))
-
-      expect(getBackendUrl(mockedFetch)).toBe(url)
-      expect(await getCachedType(getPathname(url))).toBeNull()
     })
   })
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -289,6 +289,27 @@ describe('handleRequest()', () => {
         expect(await getCachedType(getPathname(url))).toBe('Article')
       })
     })
+
+    describe('forwards authentication requests to default backend', () => {
+      test.each([
+        'https://de.serlo.org/auth/login',
+        'https://de.serlo.org/auth/logout',
+        'https://de.serlo.org/auth/activate/:token',
+        'https://de.serlo.org/auth/password/change',
+        'https://de.serlo.org/auth/password/restore/:token',
+        'https://de.serlo.org/auth/hydra/login',
+        'https://de.serlo.org/auth/hydra/consent',
+        'https://de.serlo.org/user/register',
+      ])('URL = %p', async (url) => {
+        const mockedFetch = mockFetch({ [url]: '' })
+
+        const response = (await handleRequest(new Request(url)))!
+
+        expect(getBackendUrl(mockedFetch)).toBe(url)
+        expect(response.headers.get('Set-Cookie')).toBeNull()
+        expect(await getCachedType(getPathname(url))).toBeNull()
+      })
+    })
   })
 
   describe('returns null if language tenant is not "de"', () => {

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -31,7 +31,8 @@ export async function handleRequest(
   if (
     path.startsWith('/_next/') ||
     path.startsWith('/_assets/') ||
-    path.startsWith('/api/frontend/')
+    path.startsWith('/api/frontend/') ||
+    path === '/search'
   )
     return await fetchBackend(true)
 

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -32,13 +32,13 @@ export async function handleRequest(
     path.startsWith('/_next/') ||
     path.startsWith('/_assets/') ||
     path.startsWith('/api/frontend/') ||
-    path === '/search'
+    path === '/search' ||
+    path === '/spenden'
   )
     return await fetchBackend(true)
 
   const cookies = request.headers.get('Cookie')
-  if (path === '/spenden' || cookies?.includes('authenticated=1'))
-    return await fetchBackend(false)
+  if (cookies?.includes('authenticated=1')) return await fetchBackend(false)
 
   if (path !== '/') {
     const typename = await queryTypename(path)

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -38,7 +38,19 @@ export async function handleRequest(
     return await fetchBackend(true)
 
   const cookies = request.headers.get('Cookie')
-  if (cookies?.includes('authenticated=1')) return await fetchBackend(false)
+
+  if (
+    path === '/auth/login' ||
+    path === '/auth/logout' ||
+    path.startsWith('/auth/activate/') ||
+    path === '/auth/password/change' ||
+    path.startsWith('/auth/password/restore/') ||
+    path === '/auth/hydra/login' ||
+    path === '/auth/hydra/consent' ||
+    path === '/user/register' ||
+    cookies?.includes('authenticated=1')
+  )
+    return await fetchBackend(false)
 
   if (path !== '/') {
     const typename = await queryTypename(path)


### PR DESCRIPTION
* `/search` always resolve to frontend (fixes https://github.com/serlo/frontend/issues/248)
* `/spenden` always resolve to frontend (after https://github.com/serlo/frontend/issues/170 got implemented)
* requests for authentication resolve to default backend (fixes #18 )

I'll merge it into #19 with better code for testing...