### PR TITLE
Add API for requesting current donor ids

### DIFF
--- a/__tests__/_extend-jest.ts
+++ b/__tests__/_extend-jest.ts
@@ -1,3 +1,24 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
 import { FetchMock } from './_helper'
 
 export function extendExpect() {

--- a/__tests__/active-donors.ts
+++ b/__tests__/active-donors.ts
@@ -1,41 +1,55 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
 import {
   extractUserIdsFromSheet,
-  fetchSheet,
   handleRequest,
-  isObject,
-  isSheet,
   isUserId,
-  MajorDimension,
   Options,
-  to,
 } from '../src/active-donors'
 import { createJsonResponse } from '../src/utils'
 import { mockFetch, FetchMock, expectHasOkStatus } from './_helper'
 
 describe('handleRequest()', () => {
+  const apiUrl = 'https://api.serlo.org/community/active-donors'
+
+  const commonSheetUrl =
+    'https://sheets.googleapis.com/v4/spreadsheets/active-donors' +
+    '/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=api-secret'
+
+  const commonOptions = { spreadsheetId: 'active-donors', apiKey: 'api-secret' }
+
   describe('returns response with list of user ids from spreadsheet', () => {
-    const sheetUrl =
-      'https://sheets.googleapis.com/v4/spreadsheets/active-donors-spreadsheet/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=api-secret'
     let fetch: FetchMock
     let response: Response
 
     beforeEach(async () => {
-      fetch = mockFetch({
-        [sheetUrl]: createJsonResponse({
-          values: [['Header', '10', '20', '30']],
-        }),
-      })
+      const sheetData = { values: [['Header', '10', '20', '30']] }
 
-      response = await handleUrl(
-        'https://api.serlo.org/community/active-donors',
-        {
-          spreadsheetId: 'active-donors-spreadsheet',
-          apiKey: 'api-secret',
-        }
-      )
+      fetch = mockFetch({ [commonSheetUrl]: createJsonResponse(sheetData) })
+
+      response = await handleUrl(apiUrl, commonOptions)
     })
 
-    test('response has list of user ids as JSON encoded', async () => {
+    test('response has JSON encoded list of user ids', async () => {
       expect(await response.json()).toEqual(['10', '20', '30'])
     })
 
@@ -44,40 +58,29 @@ describe('handleRequest()', () => {
     })
 
     test('spreadsheet api url was called exactly one time', () => {
-      expect(fetch).toHaveExactlyOneRequestTo(sheetUrl)
+      expect(fetch).toHaveExactlyOneRequestTo(commonSheetUrl)
     })
   })
 
-  test('"spreadsheetId" and "apiKey" are optional and their default value are set by global values', async () => {
+  test('"spreadsheetId" and "apiKey" are optional arguments', async () => {
+    const sheetData = { values: [['Header', '10', '20', '30']] }
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/global-spreadsheet-id' +
+      '/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=global-api-key'
+
     global.GOOGLE_API_KEY = 'global-api-key'
     global.SPREADSHEET_ID_ACTIVE_DONORS = 'global-spreadsheet-id'
-    const sheetUrl =
-      'https://sheets.googleapis.com/v4/spreadsheets/global-spreadsheet-id/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=global-api-key'
-    mockFetch({
-      [sheetUrl]: createJsonResponse({
-        values: [['Header', '10', '20', '30']],
-      }),
-    })
+    mockFetch({ [sheetUrl]: createJsonResponse(sheetData) })
 
-    const response = await handleUrl(
-      'https://api.serlo.org/community/active-donors'
-    )
+    const response = await handleUrl(apiUrl)
 
     expect(await response.json()).toEqual(['10', '20', '30'])
   })
 
   test('returns JSON response with empty list when an error occurred', async () => {
-    const sheetUrl =
-      'https://sheets.googleapis.com/v4/spreadsheets/active-donors-spreadsheet/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=api-secret'
-    mockFetch({ [sheetUrl]: createJsonResponse({}) })
+    mockFetch({ [commonSheetUrl]: createJsonResponse({}) })
 
-    const response = await handleUrl(
-      'https://api.serlo.org/community/active-donors',
-      {
-        spreadsheetId: 'active-donors-spreadsheet',
-        apiKey: 'api-secret',
-      }
-    )
+    const response = await handleUrl(apiUrl, commonOptions)
 
     expect(await response.json()).toEqual([])
   })
@@ -97,150 +100,32 @@ describe('handleRequest()', () => {
   })
 
   test('returns null if path is not "/community/active-donors"', async () => {
-    const response = await handleUrl('https://api.serlo.org/graphql')
-
-    expect(response).toBeNull()
+    expect(await handleUrl('https://api.serlo.org/graphql')).toBeNull()
   })
+
+  async function handleUrl(url: string, options?: Options): Promise<Response> {
+    return (await handleRequest(new Request(url), options)) as Response
+  }
 })
 
 describe('extractUserIdsFromSheet()', () => {
   test('returns list of user ids (entries of first column without the header)', () => {
-    expect(
-      extractUserIdsFromSheet({ values: [['Header', '23', '42']] })
-    ).toEqual(['23', '42'])
+    const result = extractUserIdsFromSheet({ values: [['Header', '23', '42']] })
+
+    expect(result).toEqual(['23', '42'])
   })
 
   test('wrong formatted user ids are filtered out', () => {
-    expect(
-      extractUserIdsFromSheet({ values: [['Header', '23', null, 'f56', '1']] })
-    ).toEqual(['23', '1'])
-  })
-})
-
-describe('fetchSheet()', () => {
-  test('fetches a spreadsheet via the Google Sheet API', async () => {
-    const sheetUrl =
-      'https://sheets.googleapis.com/v4/spreadsheets/my-spreadsheet/values/sheet!A:A?majorDimension=COLUMNS&key=my-secret'
-    const fetch = mockFetch({
-      [sheetUrl]: createJsonResponse({ values: [['1', '2']] }),
+    const result = extractUserIdsFromSheet({
+      values: [['Header', '23', 'f56', '1', '0.5']],
     })
 
-    const sheet = await fetchSheet({
-      spreadsheetId: 'my-spreadsheet',
-      range: 'sheet!A:A',
-      key: 'my-secret',
-      majorDimension: MajorDimension.Columns,
-    })
-
-    expect(sheet).toEqual({ values: [['1', '2']] })
-    expect(fetch).toHaveExactlyOneRequestTo(sheetUrl)
+    expect(result).toEqual(['23', '1'])
   })
 
-  test('"key" and "majorDimension" are optional arguments', async () => {
-    global.GOOGLE_API_KEY = 'global-secret'
-    const sheetUrl =
-      'https://sheets.googleapis.com/v4/spreadsheets/spreadsheet-id/values/sheet1!A1?majorDimension=ROWS&key=global-secret'
-    mockFetch({ [sheetUrl]: createJsonResponse({ values: [['1', '2']] }) })
-
-    const sheet = await fetchSheet({
-      spreadsheetId: 'spreadsheet-id',
-      range: 'sheet1!A1',
-    })
-
-    expect(sheet).toEqual({ values: [['1', '2']] })
-  })
-
-  describe('returns null in case an error occurred', () => {
-    const sheetUrl =
-      'https://sheets.googleapis.com/v4/spreadsheets/my-spreadsheet/values/sheet!A:A?majorDimension=COLUMNS&key=my-secret'
-
-    test('when the google api returns malformed json', async () => {
-      mockFetch({ [sheetUrl]: 'no-json-text' })
-
-      const sheet = await fetchSheet({
-        spreadsheetId: 'my-spreadsheet',
-        range: 'sheet!A:A',
-        key: 'my-secret',
-        majorDimension: MajorDimension.Columns,
-      })
-
-      expect(sheet).toBeNull()
-    })
-
-    test('returns null in case the result is malformed', async () => {
-      mockFetch({ [sheetUrl]: createJsonResponse({ values: null }) })
-
-      const sheet = await fetchSheet({
-        spreadsheetId: 'my-spreadsheet',
-        range: 'sheet!A:A',
-        key: 'my-secret',
-        majorDimension: MajorDimension.Columns,
-      })
-
-      expect(sheet).toBeNull()
-    })
-  })
-})
-
-describe('to()', () => {
-  type Foo = 'foo'
-
-  function isFoo(value: unknown): value is Foo {
-    return value === 'foo'
-  }
-
-  test('returns argument if it fulfills the type guard', () => {
-    expect(to(isFoo, 'foo')).toBe('foo')
-  })
-
-  test('returns null if argument does not fulfill the type guard', () => {
-    expect(to(isFoo, 'bar')).toBeNull()
-  })
-})
-
-describe('isSheet()', () => {
-  test('returns true if argument extends "{ values: unknown[][] }"', () => {
-    expect(isSheet({ values: [[1, 2, 3]] })).toBe(true)
-  })
-
-  describe('returns false if argument does not extend "{ values: unknown[][]}"', () => {
-    test('argument is no object', () => {
-      expect(isSheet(1)).toBe(false)
-    })
-
-    test('argument is null', () => {
-      expect(isSheet(null)).toBe(false)
-    })
-
-    test('argument has no "values" argument', () => {
-      expect(isSheet({})).toBe(false)
-    })
-
-    test('"values" property is not a list', () => {
-      expect(isSheet({ values: null })).toBe(false)
-    })
-
-    test('"values" property is an empty list', () => {
-      expect(isSheet({ values: [] })).toBe(false)
-    })
-  })
-
-  test('returns false if column list is empty', () => {
-    expect(isSheet({ values: [[]] })).toBe(false)
-  })
-})
-
-describe('isObject()', () => {
-  test('returns true if argument is an object', () => {
-    expect(isObject({})).toBe(true)
-  })
-
-  test('returns false if argument is null (`typeof null` results in `object`)', () => {
-    expect(isObject(null)).toBe(false)
-  })
-
-  test('returns false if argument is not an object', () => {
-    expect(isObject(1)).toBe(false)
+  test('returns empty list when no data is given', () => {
+    expect(extractUserIdsFromSheet({ values: [[]] })).toEqual([])
+    expect(extractUserIdsFromSheet({ values: [] })).toEqual([])
   })
 })
 
@@ -267,7 +152,3 @@ describe('isUserId()', () => {
     expect(isUserId(undefined)).toBe(false)
   })
 })
-
-async function handleUrl(url: string, options?: Options): Promise<Response> {
-  return (await handleRequest(new Request(url), options)) as Response
-}

--- a/__tests__/active-donors.ts
+++ b/__tests__/active-donors.ts
@@ -1,0 +1,273 @@
+import {
+  extractUserIdsFromSheet,
+  fetchSheet,
+  handleRequest,
+  isObject,
+  isSheet,
+  isUserId,
+  MajorDimension,
+  Options,
+  to,
+} from '../src/active-donors'
+import { createJsonResponse } from '../src/utils'
+import { mockFetch, FetchMock, expectHasOkStatus } from './_helper'
+
+describe('handleRequest()', () => {
+  describe('returns response with list of user ids from spreadsheet', () => {
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/active-donors-spreadsheet/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=api-secret'
+    let fetch: FetchMock
+    let response: Response
+
+    beforeEach(async () => {
+      fetch = mockFetch({
+        [sheetUrl]: createJsonResponse({
+          values: [['Header', '10', '20', '30']],
+        }),
+      })
+
+      response = await handleUrl(
+        'https://api.serlo.org/community/active-donors',
+        {
+          spreadsheetId: 'active-donors-spreadsheet',
+          apiKey: 'api-secret',
+        }
+      )
+    })
+
+    test('response has list of user ids as JSON encoded', async () => {
+      expect(await response.json()).toEqual(['10', '20', '30'])
+    })
+
+    test('response has ok status', () => {
+      expectHasOkStatus(response)
+    })
+
+    test('spreadsheet api url was called exactly one time', () => {
+      expect(fetch).toHaveExactlyOneRequestTo(sheetUrl)
+    })
+  })
+
+  test('"spreadsheetId" and "apiKey" are optional and their default value are set by global values', async () => {
+    global.GOOGLE_API_KEY = 'global-api-key'
+    global.SPREADSHEET_ID_ACTIVE_DONORS = 'global-spreadsheet-id'
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/global-spreadsheet-id/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=global-api-key'
+    mockFetch({
+      [sheetUrl]: createJsonResponse({
+        values: [['Header', '10', '20', '30']],
+      }),
+    })
+
+    const response = await handleUrl(
+      'https://api.serlo.org/community/active-donors'
+    )
+
+    expect(await response.json()).toEqual(['10', '20', '30'])
+  })
+
+  test('returns JSON response with empty list when an error occurred', async () => {
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/active-donors-spreadsheet/values/Tabellenblatt1!A:A?majorDimension=COLUMNS&key=api-secret'
+    mockFetch({ [sheetUrl]: createJsonResponse({}) })
+
+    const response = await handleUrl(
+      'https://api.serlo.org/community/active-donors',
+      {
+        spreadsheetId: 'active-donors-spreadsheet',
+        apiKey: 'api-secret',
+      }
+    )
+
+    expect(await response.json()).toEqual([])
+  })
+
+  describe('returns null if subdomain ist not "api"', () => {
+    test('when url has no subdomain', async () => {
+      const url = 'https://serlo.org/community/active-donors'
+
+      expect(await handleUrl(url)).toBeNull()
+    })
+
+    test('when subdomain is different from "api"', async () => {
+      const url = 'https://en.serlo.org/community/active-donors'
+
+      expect(await handleUrl(url)).toBeNull()
+    })
+  })
+
+  test('returns null if path is not "/community/active-donors"', async () => {
+    const response = await handleUrl('https://api.serlo.org/graphql')
+
+    expect(response).toBeNull()
+  })
+})
+
+describe('extractUserIdsFromSheet()', () => {
+  test('returns list of user ids (entries of first column without the header)', () => {
+    expect(
+      extractUserIdsFromSheet({ values: [['Header', '23', '42']] })
+    ).toEqual(['23', '42'])
+  })
+
+  test('wrong formatted user ids are filtered out', () => {
+    expect(
+      extractUserIdsFromSheet({ values: [['Header', '23', null, 'f56', '1']] })
+    ).toEqual(['23', '1'])
+  })
+})
+
+describe('fetchSheet()', () => {
+  test('fetches a spreadsheet via the Google Sheet API', async () => {
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/my-spreadsheet/values/sheet!A:A?majorDimension=COLUMNS&key=my-secret'
+    const fetch = mockFetch({
+      [sheetUrl]: createJsonResponse({ values: [['1', '2']] }),
+    })
+
+    const sheet = await fetchSheet({
+      spreadsheetId: 'my-spreadsheet',
+      range: 'sheet!A:A',
+      key: 'my-secret',
+      majorDimension: MajorDimension.Columns,
+    })
+
+    expect(sheet).toEqual({ values: [['1', '2']] })
+    expect(fetch).toHaveExactlyOneRequestTo(sheetUrl)
+  })
+
+  test('"key" and "majorDimension" are optional arguments', async () => {
+    global.GOOGLE_API_KEY = 'global-secret'
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/spreadsheet-id/values/sheet1!A1?majorDimension=ROWS&key=global-secret'
+    mockFetch({ [sheetUrl]: createJsonResponse({ values: [['1', '2']] }) })
+
+    const sheet = await fetchSheet({
+      spreadsheetId: 'spreadsheet-id',
+      range: 'sheet1!A1',
+    })
+
+    expect(sheet).toEqual({ values: [['1', '2']] })
+  })
+
+  describe('returns null in case an error occurred', () => {
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/my-spreadsheet/values/sheet!A:A?majorDimension=COLUMNS&key=my-secret'
+
+    test('when the google api returns malformed json', async () => {
+      mockFetch({ [sheetUrl]: 'no-json-text' })
+
+      const sheet = await fetchSheet({
+        spreadsheetId: 'my-spreadsheet',
+        range: 'sheet!A:A',
+        key: 'my-secret',
+        majorDimension: MajorDimension.Columns,
+      })
+
+      expect(sheet).toBeNull()
+    })
+
+    test('returns null in case the result is malformed', async () => {
+      mockFetch({ [sheetUrl]: createJsonResponse({ values: null }) })
+
+      const sheet = await fetchSheet({
+        spreadsheetId: 'my-spreadsheet',
+        range: 'sheet!A:A',
+        key: 'my-secret',
+        majorDimension: MajorDimension.Columns,
+      })
+
+      expect(sheet).toBeNull()
+    })
+  })
+})
+
+describe('to()', () => {
+  type Foo = 'foo'
+
+  function isFoo(value: unknown): value is Foo {
+    return value === 'foo'
+  }
+
+  test('returns argument if it fulfills the type guard', () => {
+    expect(to(isFoo, 'foo')).toBe('foo')
+  })
+
+  test('returns null if argument does not fulfill the type guard', () => {
+    expect(to(isFoo, 'bar')).toBeNull()
+  })
+})
+
+describe('isSheet()', () => {
+  test('returns true if argument extends "{ values: unknown[][] }"', () => {
+    expect(isSheet({ values: [[1, 2, 3]] })).toBe(true)
+  })
+
+  describe('returns false if argument does not extend "{ values: unknown[][]}"', () => {
+    test('argument is no object', () => {
+      expect(isSheet(1)).toBe(false)
+    })
+
+    test('argument is null', () => {
+      expect(isSheet(null)).toBe(false)
+    })
+
+    test('argument has no "values" argument', () => {
+      expect(isSheet({})).toBe(false)
+    })
+
+    test('"values" property is not a list', () => {
+      expect(isSheet({ values: null })).toBe(false)
+    })
+
+    test('"values" property is an empty list', () => {
+      expect(isSheet({ values: [] })).toBe(false)
+    })
+  })
+
+  test('returns false if column list is empty', () => {
+    expect(isSheet({ values: [[]] })).toBe(false)
+  })
+})
+
+describe('isObject()', () => {
+  test('returns true if argument is an object', () => {
+    expect(isObject({})).toBe(true)
+  })
+
+  test('returns false if argument is null (`typeof null` results in `object`)', () => {
+    expect(isObject(null)).toBe(false)
+  })
+
+  test('returns false if argument is not an object', () => {
+    expect(isObject(1)).toBe(false)
+  })
+})
+
+describe('isUserId()', () => {
+  test('returns true if argument is a nonempty string containing only digits', () => {
+    expect(isUserId('1')).toBe(true)
+    expect(isUserId('0000')).toBe(true)
+  })
+
+  test('returns false if argument is a string containing a character not being a digit', () => {
+    expect(isUserId('123foo')).toBe(false)
+    expect(isUserId('0.5')).toBe(false)
+    expect(isUserId('-1')).toBe(false)
+  })
+
+  test('returns false if argument is an empty string', () => {
+    expect(isUserId('')).toBe(false)
+  })
+
+  test('returns false if argument is not a string', () => {
+    expect(isUserId(1)).toBe(false)
+    expect(isUserId([])).toBe(false)
+    expect(isUserId({})).toBe(false)
+    expect(isUserId(undefined)).toBe(false)
+  })
+})
+
+async function handleUrl(url: string, options?: Options): Promise<Response> {
+  return (await handleRequest(new Request(url), options)) as Response
+}

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -1,3 +1,24 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
 import { api, fetchApi } from '../src/api'
 import { mockFetch, FetchMock } from './_helper'
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -1,3 +1,24 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
 import { handleRequest, createApiQuery } from '../src/frontend-proxy'
 import { getPathname } from '../src/url-utils'
 import { createJsonResponse } from '../src/utils'

--- a/__tests__/google-api-utils.ts
+++ b/__tests__/google-api-utils.ts
@@ -1,0 +1,123 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
+import { fetchSheet, MajorDimension, isSheet } from '../src/google-api-utils'
+import { createJsonResponse } from '../src/utils'
+import { mockFetch } from './_helper'
+
+describe('fetchSheet()', () => {
+  const commonSheetUrl =
+    'https://sheets.googleapis.com/v4/spreadsheets/my-spreadsheet-id' +
+    '/values/sheet1!A:A?majorDimension=COLUMNS&key=my-secret'
+
+  const commonFetchSheetArgs = {
+    spreadsheetId: 'my-spreadsheet-id',
+    range: 'sheet1!A:A',
+    apiKey: 'my-secret',
+    majorDimension: MajorDimension.Columns,
+  }
+
+  test('fetches a spreadsheet via the Google Sheet API', async () => {
+    const fetch = mockFetch({
+      [commonSheetUrl]: createJsonResponse({ values: [['1', '2']] }),
+    })
+
+    const sheet = await fetchSheet(commonFetchSheetArgs)
+
+    expect(sheet).toEqual({ values: [['1', '2']] })
+    expect(fetch).toHaveExactlyOneRequestTo(commonSheetUrl)
+  })
+
+  test('"key" and "majorDimension" are optional arguments', async () => {
+    const sheetUrl =
+      'https://sheets.googleapis.com/v4/spreadsheets/spreadsheet-id' +
+      '/values/sheet1!A1?majorDimension=ROWS&key=global-secret'
+
+    global.GOOGLE_API_KEY = 'global-secret'
+    mockFetch({ [sheetUrl]: createJsonResponse({ values: [['1', '2']] }) })
+
+    const sheet = await fetchSheet({
+      spreadsheetId: 'spreadsheet-id',
+      range: 'sheet1!A1',
+    })
+
+    expect(sheet).toEqual({ values: [['1', '2']] })
+  })
+
+  describe('returns null in case an error occurred', () => {
+    test('when the google api returns malformed json', async () => {
+      mockFetch({ [commonSheetUrl]: 'no-json-text' })
+
+      const sheet = await fetchSheet(commonFetchSheetArgs)
+
+      expect(sheet).toBeNull()
+    })
+
+    test('when the result does not extend type Sheet', async () => {
+      mockFetch({ [commonSheetUrl]: createJsonResponse({ values: null }) })
+
+      const sheet = await fetchSheet(commonFetchSheetArgs)
+
+      expect(sheet).toBeNull()
+    })
+  })
+})
+
+describe('isSheet()', () => {
+  describe('returns true if argument extends type Sheet', () => {
+    test('matrix of entries is not empty', () => {
+      const data = { values: [['1', '2', '3'], ['4']] }
+
+      expect(isSheet(data)).toBe(true)
+    })
+
+    test('matrix of entries is empty', () => {
+      expect(isSheet({ values: [[]] })).toBe(true)
+      expect(isSheet({ values: [] })).toBe(true)
+    })
+  })
+
+  describe('returns false if argument does not extend type Sheet', () => {
+    test('argument is no object', () => {
+      expect(isSheet(1)).toBe(false)
+    })
+
+    test('argument is null', () => {
+      expect(isSheet(null)).toBe(false)
+    })
+
+    test('argument has no "values" argument', () => {
+      expect(isSheet({})).toBe(false)
+    })
+
+    test('"values" property is not a list', () => {
+      expect(isSheet({ values: null })).toBe(false)
+    })
+
+    test('"values" list contains a non list', () => {
+      expect(isSheet({ values: [['1'], 1] })).toBe(false)
+    })
+
+    test('entries of "values" are not strings', () => {
+      expect(isSheet({ values: [['1'], [1]] })).toBe(false)
+    })
+  })
+})

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -24,10 +24,12 @@ import { h } from 'preact'
 
 import { Template } from '../src/ui'
 import {
+  convertTo,
   sanitizeHtml,
   markdownToHtml,
   fetchWithCache,
   isLanguageCode,
+  isNotNullable,
   createPreactResponse,
   createJsonResponse,
   createNotFoundResponse,
@@ -123,5 +125,39 @@ describe('fetchWithCache()', () => {
       'http://example.com/',
       { cf: { cacheTtl: 3600 } },
     ])
+  })
+})
+
+describe('convertTo()', () => {
+  type Foo = 'foo'
+
+  function isFoo(value: unknown): value is Foo {
+    return value === 'foo'
+  }
+
+  test('returns argument if it fulfills the type guard', () => {
+    expect(convertTo(isFoo, 'foo')).toBe('foo')
+  })
+
+  test('returns null if argument does not fulfill the type guard', () => {
+    expect(convertTo(isFoo, 'bar')).toBeNull()
+  })
+})
+
+describe('isNotNullable()', () => {
+  test('returns false for null', () => {
+    expect(isNotNullable(null)).toBe(false)
+  })
+
+  test('returns false for undefined', () => {
+    expect(isNotNullable(undefined)).toBe(false)
+  })
+
+  test('returns true for all other values', () => {
+    expect(isNotNullable([])).toBe(true)
+    expect(isNotNullable({})).toBe(true)
+    expect(isNotNullable('')).toBe(true)
+    expect(isNotNullable(true)).toBe(true)
+    expect(isNotNullable(1)).toBe(true)
   })
 })

--- a/src/active-donors.ts
+++ b/src/active-donors.ts
@@ -1,0 +1,109 @@
+import { getPathname, getSubdomain } from './url-utils'
+import { createJsonResponse } from './utils'
+
+// See https://www.everythingfrontend.com/posts/newtype-in-typescript.html
+type UserId = string & { readonly __tag: unique symbol }
+
+interface Sheet {
+  values: unknown[][]
+}
+
+export interface Options {
+  spreadsheetId?: string
+  apiKey?: string
+}
+
+export enum MajorDimension {
+  Rows = 'ROWS',
+  Columns = 'COLUMNS',
+}
+
+export async function handleRequest(
+  req: Request,
+  opt?: Options
+): Promise<Response | null> {
+  const url = req.url
+
+  if (getSubdomain(url) !== 'api') return null
+  if (getPathname(url) !== '/community/active-donors') return null
+
+  const spreadsheetId =
+    opt?.spreadsheetId ?? global.SPREADSHEET_ID_ACTIVE_DONORS
+  const apiKey = opt?.apiKey ?? global.GOOGLE_API_KEY
+
+  const sheet = await fetchSheet({
+    spreadsheetId,
+    range: 'Tabellenblatt1!A:A',
+    key: apiKey,
+    majorDimension: MajorDimension.Columns,
+  })
+
+  const userIds = sheet !== null ? extractUserIdsFromSheet(sheet) : null
+
+  return createJsonResponse(userIds ?? [])
+}
+
+export async function fetchSheet({
+  spreadsheetId,
+  range,
+  key = global.GOOGLE_API_KEY,
+  majorDimension = MajorDimension.Rows,
+}: {
+  spreadsheetId: string
+  range: string
+  key?: string
+  majorDimension?: MajorDimension
+}): Promise<Sheet | null> {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${range}?majorDimension=${majorDimension}&key=${key}`
+  const response = await fetch(url)
+  let data
+
+  try {
+    data = await response.json()
+  } catch (error) {
+    return null
+  }
+
+  return to(isSheet, data)
+}
+
+export function extractUserIdsFromSheet(sheet: Sheet): UserId[] | null {
+  const column = sheet !== null ? sheet.values[0].slice(1) : null
+  const userIds =
+    column !== null
+      ? column.map((entry) => to(isUserId, entry)).filter(notEmpty)
+      : null
+
+  return userIds
+}
+
+export function to<A>(
+  typeGuard: (value: unknown) => value is A,
+  data: unknown
+): A | null {
+  return typeGuard(data) ? data : null
+}
+
+export function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value != null
+}
+
+export function isSheet(data: unknown): data is Sheet {
+  return (
+    isObject(data) &&
+    //@ts-ignore
+    Array.isArray(data.values) &&
+    //@ts-ignore
+    Array.isArray(data.values[0]) &&
+    //@ts-ignore
+    data.values[0].length > 0
+  )
+}
+
+export function isUserId(value: unknown): value is UserId {
+  return typeof value === 'string' && /^\d+$/.test(value)
+}
+
+function notEmpty<A>(value: A | null): value is A {
+  return value != null
+}

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -1,3 +1,24 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
 import { fetchApi } from './api'
 import { getSubdomain, getPathname, hasContentApiParameters } from './url-utils'
 

--- a/src/google-api-utils.ts
+++ b/src/google-api-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
+import * as R from 'ramda'
+
+import { convertTo } from './utils'
+
+export interface Sheet {
+  values: string[][]
+}
+
+export enum MajorDimension {
+  Rows = 'ROWS',
+  Columns = 'COLUMNS',
+}
+
+export async function fetchSheet({
+  spreadsheetId,
+  range,
+  apiKey = global.GOOGLE_API_KEY,
+  majorDimension = MajorDimension.Rows,
+}: {
+  spreadsheetId: string
+  range: string
+  apiKey?: string
+  majorDimension?: MajorDimension
+}): Promise<Sheet | null> {
+  const url =
+    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}` +
+    `/values/${range}?majorDimension=${majorDimension}&key=${apiKey}`
+  const response = await fetch(url)
+  let data: unknown
+
+  try {
+    data = await response.json()
+  } catch (error) {
+    return null
+  }
+
+  return convertTo(isSheet, data)
+}
+
+export function isSheet(data: unknown): data is Sheet {
+  const isStringArray = (data: unknown) =>
+    Array.isArray(data) && data.every((entry) => R.is(String, entry))
+
+  const isArrayOfStringArrays = (data: unknown) =>
+    Array.isArray(data) && data.every(isStringArray)
+
+  return (
+    R.is(Object, data) && R.propSatisfies(isArrayOfStringArrays, 'values', data)
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
+import { handleRequest as activeDonors } from './active-donors'
 import { api } from './api'
 import { edtrIoStats } from './are-we-edtr-io-yet'
 import { handleRequest as frontendProxy } from './frontend-proxy'
@@ -40,6 +41,7 @@ export async function handleRequest(request: Request) {
     (await staticPages(request)) ||
     (await semanticFileNames(request)) ||
     (await packages(request)) ||
+    (await activeDonors(request)) ||
     (await api(request)) ||
     (await frontendProxy(request)) ||
     (await fetch(request))

--- a/src/secrets.d.ts
+++ b/src/secrets.d.ts
@@ -22,5 +22,6 @@
 declare namespace NodeJS {
   interface Global {
     API_SECRET: string
+    GOOGLE_API_KEY: string
   }
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -22,6 +22,7 @@
 import marked from 'marked'
 import { h, VNode } from 'preact'
 import renderToString from 'preact-render-to-string'
+import * as R from 'ramda'
 import sanitize from 'sanitize-html'
 
 import { NotFound } from './ui'
@@ -35,8 +36,19 @@ export enum LanguageCode {
   Es = 'es',
 }
 
+export function convertTo<A>(
+  typeGuard: (value: unknown) => value is A,
+  data: unknown
+): A | null {
+  return typeGuard(data) ? data : null
+}
+
 export function isLanguageCode(code: string): code is LanguageCode {
   return Object.values(LanguageCode).some((x) => x === code)
+}
+
+export function isNotNullable<A>(value: A): value is NonNullable<A> {
+  return !R.isNil(value)
 }
 
 export function sanitizeHtml(html: string): string {

--- a/src/vars.d.ts
+++ b/src/vars.d.ts
@@ -28,5 +28,6 @@ declare namespace NodeJS {
     FRONTEND_DOMAIN: string
     FRONTEND_PROBABILITY: string
     fetch: typeof fetch
+    SPREADSHEET_ID_ACTIVE_DONORS: string
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,10 +15,11 @@ kv-namespaces = [
 [env.dev.vars]
 API_ENDPOINT = "https://api.serlo-development.dev/graphql"
 DOMAIN = "serlo-development.dev"
+ENABLE_BASIC_AUTH = "true"
 FRONTEND_DOMAIN = "frontend.serlo.now.sh"
 FRONTEND_PROBABILITY = "0.50"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
-ENABLE_BASIC_AUTH = "true"
+SPREADSHEET_ID_ACTIVE_DONORS = "1t2hIPx6eJVQrS1Tmj7PqfkNZcp5GlsXEX41yhpmVXhs"
 
 [env.staging]
 name = "serlo-staging"
@@ -33,10 +34,11 @@ kv-namespaces = [
 [env.staging.vars]
 API_ENDPOINT = "https://api.serlo-staging.dev/graphql"
 DOMAIN = "serlo-staging.dev"
+ENABLE_BASIC_AUTH = "true"
 FRONTEND_DOMAIN = "frontend.serlo.now.sh"
 FRONTEND_PROBABILITY = "0.50"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
-ENABLE_BASIC_AUTH = "true"
+SPREADSHEET_ID_ACTIVE_DONORS = "1t2hIPx6eJVQrS1Tmj7PqfkNZcp5GlsXEX41yhpmVXhs"
 
 [env.production]
 name = "serlo-production"
@@ -55,3 +57,4 @@ ENABLE_BASIC_AUTH = "false"
 FRONTEND_DOMAIN = "frontend.serlo.org"
 FRONTEND_PROBABILITY = "0.1"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
+SPREADSHEET_ID_ACTIVE_DONORS = "16I02_MTn-RGTs0FHtim2nF31QjzaWwDK2SkFOf8TVVU"


### PR DESCRIPTION
This PR adds the endpoint `https://api.serlo.org/community/active-donors` which returns the list of active donors as a JSON response (needed for https://github.com/serlo/serlo.org/issues/404 ).

Example: [`https://api.serlo-development.dev/community/active-donors`](https://api.serlo-development.dev/community/active-donors) (it returns the user ids from the dummy table https://docs.google.com/spreadsheets/d/1t2hIPx6eJVQrS1Tmj7PqfkNZcp5GlsXEX41yhpmVXhs/edit#gid=0 ).

The PR is ready to be reviewed. However there are some questions left which I want to discuss with @inyono (See comments below).

The following is missing:

- [ ] In case we stay with an endpoint like `https://api.serlo-development.dev/community/active-donors` we need to add the header `Access-Control-Allow-Origin` so that we can use the URL at serlo.org in JS scripts
- [ ] Cache fetch Request for 1h