### PR TITLE
prepare cloudflare worker for frontend auth

### DIFF
--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -32,6 +32,12 @@ export function expectContentTypeIsHtml(response: Response): void {
   expect(response.headers.get('Content-Type')).toBe('text/html;charset=utf-8')
 }
 
+export function expectContentTypeIsJson(response: Response): void {
+  expect(response.headers.get('Content-Type')).toBe(
+    'application/json;charset=utf-8'
+  )
+}
+
 export function expectHasOkStatus(response: Response): void {
   expect(response).not.toBeNull()
   expect(response.status).toBe(200)

--- a/__tests__/auth.ts
+++ b/__tests__/auth.ts
@@ -1,0 +1,17 @@
+import { handleRequest } from '../src'
+import { expectIsJsonResponse } from './_helper'
+
+test('Frontend Sector Identifier URI Validation', async () => {
+  global.DOMAIN = 'serlo.org'
+  const response = await handleRequest(
+    new Request('https://serlo.org/auth/frontend-redirect-uris.json')
+  )
+  await expectIsJsonResponse(response, [
+    'https://de.serlo.org/api/auth/callback',
+    'https://en.serlo.org/api/auth/callback',
+    'https://es.serlo.org/api/auth/callback',
+    'https://fr.serlo.org/api/auth/callback',
+    'https://hi.serlo.org/api/auth/callback',
+    'https://ta.serlo.org/api/auth/callback',
+  ])
+})

--- a/__tests__/static-pages.tsx
+++ b/__tests__/static-pages.tsx
@@ -27,7 +27,7 @@ import {
   RevisedConfig,
   RevisedType,
   UnrevisedType,
-  handleRequest,
+  staticPages,
   getPage,
   getRevisions,
   findRevisionById,
@@ -69,7 +69,7 @@ describe('handleRequest()', () => {
   }
 
   async function testHandleRequest(url: string): Promise<Response | null> {
-    return handleRequest(new Request(url), unrevisedConfig, revisedConfig)
+    return staticPages(new Request(url), unrevisedConfig, revisedConfig)
   }
 
   describe('returns unrevised page response at /imprint (html specification)', () => {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,22 @@
+import { Instance } from '../instance'
+import { getPathnameWithoutTrailingSlash, getSubdomain } from '../url-utils'
+
+export function authFrontendSectorIdentifierUriValidation(
+  request: Request
+): Response | null {
+  const { url } = request
+  if (
+    getSubdomain(url) !== null ||
+    getPathnameWithoutTrailingSlash(url) !== '/auth/frontend-redirect-uris.json'
+  ) {
+    return null
+  }
+  const redirectUris = Object.values(Instance).map((instance) => {
+    return `https://${instance}.${global.DOMAIN}/api/auth/callback`
+  })
+  return new Response(JSON.stringify(redirectUris), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,10 @@
  */
 import { api } from './api'
 import { edtrIoStats } from './are-we-edtr-io-yet'
-import { handleRequest as frontendProxy } from './frontend-proxy'
+import { authFrontendSectorIdentifierUriValidation } from './auth'
+import { frontendProxy } from './frontend-proxy'
 import { maintenanceMode } from './maintenance'
-import { handleRequest as staticPages } from './static-pages'
+import { staticPages } from './static-pages'
 import { getPathnameWithoutTrailingSlash, getSubdomain } from './url-utils'
 
 addEventListener('fetch', (event: Event) => {
@@ -33,6 +34,7 @@ addEventListener('fetch', (event: Event) => {
 
 export async function handleRequest(request: Request) {
   return (
+    authFrontendSectorIdentifierUriValidation(request) ||
     (await edtrIoStats(request)) ||
     (await maintenanceMode(request)) ||
     (await enforceHttps(request)) ||

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,0 +1,8 @@
+export enum Instance {
+  De = 'de',
+  En = 'en',
+  Es = 'es',
+  Fr = 'fr',
+  Hi = 'hi',
+  Ta = 'ta',
+}

--- a/src/static-pages/index.tsx
+++ b/src/static-pages/index.tsx
@@ -70,7 +70,7 @@ export interface RevisedPage extends Page, RevisedSpec {
 
 export type WithContent<A extends Spec> = A & { content: string }
 
-export async function handleRequest(
+export async function staticPages(
   request: Request,
   unrevisedConfig = defaultUnrevisedConfig,
   revisedConfig = defaultRevisedConfig

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -36,6 +36,10 @@ export function getPathname(url: string): string {
   return new URL(url).pathname
 }
 
+export function getQueryString(url: string): string {
+  return new URL(url).search
+}
+
 export function getPathnameWithoutTrailingSlash(url: string): string {
   const pathname = getPathname(url)
 

--- a/src/vars.d.ts
+++ b/src/vars.d.ts
@@ -27,6 +27,7 @@ declare namespace NodeJS {
     FRONTEND_ALLOWED_TYPES: string
     FRONTEND_DOMAIN: string
     FRONTEND_PROBABILITY: string
+    REDIRECT_AUTHENTICATED_USERS_TO_LEGACY_BACKEND: 'true' | 'false'
     fetch: typeof fetch
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,6 +19,7 @@ FRONTEND_DOMAIN = "frontend.serlo.now.sh"
 FRONTEND_PROBABILITY = "0.50"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
 ENABLE_BASIC_AUTH = "true"
+REDIRECT_AUTHENTICATED_USERS_TO_LEGACY_BACKEND = "false"
 
 [env.staging]
 name = "serlo-staging"
@@ -37,6 +38,7 @@ FRONTEND_DOMAIN = "frontend.serlo.now.sh"
 FRONTEND_PROBABILITY = "0.50"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
 ENABLE_BASIC_AUTH = "true"
+REDIRECT_AUTHENTICATED_USERS_TO_LEGACY_BACKEND = "false"
 
 [env.production]
 name = "serlo-production"
@@ -55,3 +57,4 @@ ENABLE_BASIC_AUTH = "false"
 FRONTEND_DOMAIN = "frontend.serlo.org"
 FRONTEND_PROBABILITY = "0.1"
 FRONTEND_ALLOWED_TYPES = '["Article", "Applet", "Course", "CoursePage", "Page", "TaxonomyTerm", "Video"]'
+REDIRECT_AUTHENTICATED_USERS_TO_LEGACY_BACKEND = "true"


### PR DESCRIPTION
# Changelog

## Added

- **auth**. Add `https://serlo.org/auth/frontend-redirect-uris.json` for https://openid.net/specs/openid-connect-registration-1_0.html#SectorIdentifierValidation.

## Changed

- **frontend-proxy**. Add var `REDIRECT_AUTHENTICATED_USERS_TO_LEGACY_BACKEND` that decides whether authenticated users should be redirected to the legacy backend (current behavior). With this, we can already test frontend authentication on staging environment.
- **frontend-proxy**.  Resolve `/api/auth/*` to frontend.

## Fixed

- **frontend-proxy**. Pass query string to backend.