### PR TITLE
redirects: Handle URL- and non-URL-encoded aliases

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -136,17 +136,34 @@ describe('Redirects', () => {
       expect(await response.text()).toBe('article content')
     })
 
-    test('handles URL encodings correctly', async () => {
-      mockFetch({
-        'https://de.serlo.org/größen': 'article content',
-        'https://api.serlo.org/graphql': createJsonResponse({
-          data: { uuid: { __typename: 'Article', alias: '/größen' } },
-        }),
+    describe('handles URL encodings correctly', () => {
+      test('API result is URL encoded', async () => {
+        mockFetch({
+          'https://de.serlo.org/größen': 'article content',
+          'https://api.serlo.org/graphql': createJsonResponse({
+            data: {
+              uuid: { __typename: 'Article', alias: '/gr%C3%B6%C3%9Fen' },
+            },
+          }),
+        })
+
+        const response = await handleUrl('https://de.serlo.org/größen')
+
+        expect(await response.text()).toBe('article content')
       })
 
-      const response = await handleUrl('https://de.serlo.org/größen')
+      test('API result is not URL encoded', async () => {
+        mockFetch({
+          'https://de.serlo.org/größen': 'article content',
+          'https://api.serlo.org/graphql': createJsonResponse({
+            data: { uuid: { __typename: 'Article', alias: '/größen' } },
+          }),
+        })
 
-      expect(await response.text()).toBe('article content')
+        const response = await handleUrl('https://de.serlo.org/größen')
+
+        expect(await response.text()).toBe('article content')
+      })
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,12 @@ async function redirects(request: Request) {
   if (isInstance(subdomain)) {
     const pathInfo = await getPathInfo(subdomain, path)
 
-    if (pathInfo !== null && decodeURIComponent(path) != pathInfo.currentPath) {
+    // TODO: Remove decodeURIComponent() when we the API returns an
+    // URL encoded alias
+    if (
+      pathInfo !== null &&
+      decodeURIComponent(path) != decodeURIComponent(pathInfo.currentPath)
+    ) {
       const url = new URL(request.url)
 
       url.pathname = pathInfo.currentPath


### PR DESCRIPTION
@inyono As discussed here is the hotfix so that the cloudflare-worker accepts url encoded and non url encoded alias of api.serlo.org