### PR TITLE
utils: Reduce max cache key to 512 characters

### DIFF
--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -302,6 +302,32 @@ describe('getPathInfo()', () => {
       )
     })
 
+    test('cache key has maximum width of 512 characters by sha-1 hashing longer keys', async () => {
+      const longTamilPath =
+        '/%E0%AE%87%E0%AE%B2%E0%AE%95%E0%AF%8D%E0%AE%95%E0%AE%A3%E0' +
+        '%AE%AE%E0%AF%8D/%E0%AE%85%E0%AE%9F%E0%AE%BF%E0%AE%AA%E0%AF%8D%E0' +
+        '%AE%AA%E0%AE%9F%E0%AF%88-%E0%AE%87%E0%AE%B2%E0%AE%95%E0%AF%8D%E0' +
+        '%AE%95%E0%AE%A3%E0%AE%AE%E0%AF%8D/%E0%AE%AE%E0%AF%8A%E0%AE%B4%E0' +
+        '%AE%BF%E0%AE%AF%E0%AE%BF%E0%AE%A9%E0%AF%8D-%E0%AE%9A%E0%AF%8A%E0' +
+        '%AE%B1%E0%AF%8D%E0%AE%AA%E0%AE%BE%E0%AE%95%E0%AF%81%E0%AE%AA%E0' +
+        '%AE%BE%E0%AE%9F%E0%AF%81-%E0%AE%87%E0%AE%B2%E0%AE%95%E0%AF%8D%E0' +
+        '%AE%95%E0%AE%BF%E0%AE%AF-%E0%AE%B5%E0%AE%95%E0%AF%88%E0%AE%95%E0' +
+        '%AE%B3%E0%AF%8D'
+      mockFetch({
+        [apiEndpoint]: createApiResponse({
+          __typename: 'Article',
+          alias: longTamilPath,
+        }),
+      })
+
+      await getPathInfo(Instance.Ta, longTamilPath)
+
+      const cacheKey = '23e2e346e649c466a41fabf38d7e8bf03333b007'
+      expect(await global.PATH_INFO_KV.get(cacheKey)).toEqual(
+        JSON.stringify({ typename: 'Article', currentPath: longTamilPath })
+      )
+    })
+
     describe('ignores malformed cache values', () => {
       const target = { typename: 'Article', currentPath: '/current-path' }
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,7 +21,9 @@
  */
 // eslint-disable-next-line import/no-unassigned-import
 import '@testing-library/jest-dom'
+import * as cryptoNode from 'crypto'
 import { Response as NodeResponse, Request as NodeRequest } from 'node-fetch'
+import * as util from 'util'
 
 import { extendExpect } from './__tests__/_extend-jest'
 import { mockKV } from './__tests__/_helper'
@@ -47,6 +49,19 @@ beforeEach(() => {
   mockKV('PATH_INFO_KV', {})
 })
 
+global.crypto = ({
+  subtle: {
+    digest(encoding: string, message: Uint8Array) {
+      return Promise.resolve(
+        cryptoNode
+          .createHash(encoding.toLowerCase().replace('-', ''))
+          .update(message)
+          .digest()
+      )
+    },
+  },
+} as unknown) as typeof crypto
+global.TextEncoder = util.TextEncoder
 global.Response = (NodeResponse as unknown) as typeof Response
 global.Request = (NodeRequest as unknown) as typeof Request
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -81,7 +81,7 @@ export async function getPathInfo(
   if (path.startsWith(userProfilePrefix) && !userProfileId.test(path))
     return { typename: 'User', currentPath: path }
 
-  const cacheKey = `/${lang}${path}`
+  const cacheKey = await toCacheKey(`/${lang}${path}`)
   const cachedValue = await global.PATH_INFO_KV.get(cacheKey)
 
   if (cachedValue !== null) {
@@ -209,4 +209,16 @@ export function createJsonResponse(json: unknown) {
 
 export function createNotFoundResponse() {
   return createPreactResponse(<NotFound />, { status: 404 })
+}
+
+async function toCacheKey(key: string): Promise<string> {
+  return key.length > 512 ? await digestMessage(key) : key
+}
+
+async function digestMessage(message: string): Promise<string> {
+  const msgUint8 = new TextEncoder().encode(message)
+  const hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+  return hashHex
 }


### PR DESCRIPTION
Fixes #55 

Idea: When the cache key has more than 512 characters the sha-1 hash of it is taken. I would use the sha-1 hash because then we have no collision for longer keys (e.g. two paths which are so long that they are the same for the first 512 characters).