### PR TITLE
Tried to add the resolver to mockApi

### DIFF
--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -20,7 +20,6 @@
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
 
-import { string } from 'io-ts'
 import { rest, ResponseResolver, restContext, MockedRequest } from 'msw'
 
 export async function expectContainsText(response: Response, texts: string[]) {
@@ -98,6 +97,30 @@ export function mockApi(uuid: unknown) {
   )
 }
 
+export function apiToReturnError(options?: { status?: number }): void {
+  global.server.use(
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
+      res.once(ctx.status(options?.status ?? 404))
+    )
+  )
+}
+
+export function apiToReturnMalformedJson(): void {
+  global.server.use(
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
+      res.once(ctx.body('malformed json'))
+    )
+  )
+}
+
+export function apiToReturn(body: unknown): void {
+  global.server.use(
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
+      res.once(ctx.json(body as Record<string, unknown>))
+    )
+  )
+}
+
 export function returnText(
   body: string,
   { status = 200 }: { status?: number } = {}
@@ -107,31 +130,4 @@ export function returnText(
 
 export function returnJson(json: Record<string, unknown>): RestResolver {
   return (_req, res, ctx) => res.once(ctx.json(json))
-}
-
-export function apiToReturnError(options?: { status?: number }): void {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
-      res.once(ctx.status(options?.status ?? 404))
-    )
-  )
-}
-
-export function apiToReturnMalformedJson(
-  options?: string,
-  { status = 200 }: { status?: number } = {}
-): void {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
-      res.once(ctx.body(string), ctx.status(status))
-    )
-  )
-}
-
-export function apiToReturnEmptyJson(options?: { status?: number }): void {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
-      res.once(ctx.status(options?.status ?? 200))
-    )
-  )
 }

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -20,6 +20,7 @@
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
 
+import { string } from 'io-ts'
 import { rest, ResponseResolver, restContext, MockedRequest } from 'msw'
 
 export async function expectContainsText(response: Response, texts: string[]) {
@@ -116,11 +117,21 @@ export function apiToReturnError(options?: { status?: number }): void {
   )
 }
 
-/*
-export function apiToReturnMalformedJson(json: Record<string,unknown>): void{
+export function apiToReturnMalformedJson(
+  options?: string,
+  { status = 200 }: { status?: number } = {}
+): void {
   global.server.use(
-    res.post(global.API_ENDPOINT, (_req, res, ctx) =>
-    res.once(ctx.json(json)))
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
+      res.once(ctx.body(string), ctx.status(status))
+    )
   )
 }
-*/
+
+export function apiToReturnEmptyJson(options?: { status?: number }): void {
+  global.server.use(
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
+      res.once(ctx.status(options?.status ?? 200))
+    )
+  )
+}

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -89,7 +89,12 @@ export function mockHttpGet(url: string, resolver: RestResolver) {
   )
 }
 
-export function apiReturns(uuid: unknown) {
+export function apiReturns(uuid: {
+  __typename?: string
+  username?: string
+  alias?: string
+  pages?: { alias: string }[]
+}) {
   mockApi(returnJson({ data: { uuid } }))
 }
 

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -89,36 +89,16 @@ export function mockHttpGet(url: string, resolver: RestResolver) {
   )
 }
 
-export function mockApi(uuid: unknown) {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) => {
-      return res(ctx.json({ data: { uuid } }))
-    })
-  )
+export function apiReturns(uuid: unknown) {
+  mockApi(returnJson({ data: { uuid } }))
 }
 
-export function apiToReturnError(options?: { status?: number }): void {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
-      res.once(ctx.status(options?.status ?? 404))
-    )
-  )
+export function mockApi(resolver: RestResolver) {
+  global.server.use(rest.post(global.API_ENDPOINT, resolver))
 }
 
-export function apiToReturnMalformedJson(): void {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
-      res.once(ctx.body('malformed json'))
-    )
-  )
-}
-
-export function apiToReturn(body: unknown): void {
-  global.server.use(
-    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
-      res.once(ctx.json(body as Record<string, unknown>))
-    )
-  )
+export function returnMalformedJson(): RestResolver {
+  return returnText('malformed json')
 }
 
 export function returnText(
@@ -128,6 +108,10 @@ export function returnText(
   return (_req, res, ctx) => res.once(ctx.body(body), ctx.status(status))
 }
 
-export function returnJson(json: Record<string, unknown>): RestResolver {
-  return (_req, res, ctx) => res.once(ctx.json(json))
+export function returnJson(json: unknown): RestResolver {
+  return (_req, res, ctx) => res.once(ctx.json(json as Record<string, unknown>))
+}
+
+export function returnBadRequest(): RestResolver {
+  return (_req, res, ctx) => res.once(ctx.status(400))
 }

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -108,9 +108,14 @@ export function returnJson(json: Record<string, unknown>): RestResolver {
   return (_req, res, ctx) => res.once(ctx.json(json))
 }
 
-export function apiToReturnError(url: string, { status = 404 }): void {
+export function apiToReturnError(
+  url: string,
+  options?: { status?: number }
+): void {
   global.server.use(
-    rest.post(url, (_req, res, ctx) => res.once(ctx.status(status)))
+    rest.post(url, (_req, res, ctx) =>
+      res.once(ctx.status(options?.status ?? 404))
+    )
   )
 }
 

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -89,8 +89,12 @@ export function mockHttpGet(url: string, resolver: RestResolver) {
   )
 }
 
-export function mockHttpPost(url: string, resolver: RestResolver) {
-  global.server.use(rest.post(url, resolver))
+export function mockApi(url: string, uuid: unknown) {
+  global.server.use(
+    rest.post(url, (req, res, ctx) => {
+      return res(ctx.json({ data: { uuid } }))
+    })
+  )
 }
 
 export function returnText(
@@ -104,6 +108,10 @@ export function returnJson(json: Record<string, unknown>): RestResolver {
   return (_req, res, ctx) => res.once(ctx.json(json))
 }
 
-export function returnApiUuid(uuid: unknown): RestResolver {
+export function apiToReturnError(body: string, { status = 404 }): RestResolver {
+  return (_req, res, ctx) => res.once(ctx.status(status))
+}
+
+export function apiUuid(uuid: unknown): RestResolver {
   return returnJson({ data: { uuid } })
 }

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -89,9 +89,9 @@ export function mockHttpGet(url: string, resolver: RestResolver) {
   )
 }
 
-export function mockApi(url: string, uuid: unknown) {
+export function mockApi(uuid: unknown) {
   global.server.use(
-    rest.post(url, (_req, res, ctx) => {
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) => {
       return res(ctx.json({ data: { uuid } }))
     })
   )
@@ -108,17 +108,19 @@ export function returnJson(json: Record<string, unknown>): RestResolver {
   return (_req, res, ctx) => res.once(ctx.json(json))
 }
 
-export function apiToReturnError(
-  url: string,
-  options?: { status?: number }
-): void {
+export function apiToReturnError(options?: { status?: number }): void {
   global.server.use(
-    rest.post(url, (_req, res, ctx) =>
+    rest.post(global.API_ENDPOINT, (_req, res, ctx) =>
       res.once(ctx.status(options?.status ?? 404))
     )
   )
 }
 
-export function apiUuid(uuid: unknown): RestResolver {
-  return returnJson({ data: { uuid } })
+/*
+export function apiToReturnMalformedJson(json: Record<string,unknown>): void{
+  global.server.use(
+    res.post(global.API_ENDPOINT, (_req, res, ctx) =>
+    res.once(ctx.json(json)))
+  )
 }
+*/

--- a/__tests__/_helper.ts
+++ b/__tests__/_helper.ts
@@ -91,7 +91,7 @@ export function mockHttpGet(url: string, resolver: RestResolver) {
 
 export function mockApi(url: string, uuid: unknown) {
   global.server.use(
-    rest.post(url, (req, res, ctx) => {
+    rest.post(url, (_req, res, ctx) => {
       return res(ctx.json({ data: { uuid } }))
     })
   )
@@ -108,8 +108,10 @@ export function returnJson(json: Record<string, unknown>): RestResolver {
   return (_req, res, ctx) => res.once(ctx.json(json))
 }
 
-export function apiToReturnError(body: string, { status = 404 }): RestResolver {
-  return (_req, res, ctx) => res.once(ctx.status(status))
+export function apiToReturnError(url: string, { status = 404 }): void {
+  global.server.use(
+    rest.post(url, (_req, res, ctx) => res.once(ctx.status(status)))
+  )
 }
 
 export function apiUuid(uuid: unknown): RestResolver {

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -1,14 +1,16 @@
 import { api, fetchApi } from '../src/api'
-import { mockHttpGet, returnText } from './_helper'
+import { mockHttpGet, apiReturns } from './_helper'
 
 describe('api()', () => {
   test('uses fetch() for requests to the serlo api', async () => {
-    mockHttpGet('https://api.serlo.org/graphql', returnText('<api-result>'))
+    apiReturns({ username: 'inyono' })
 
-    const req = new Request('https://api.serlo.org/graphql')
+    const req = new Request('https://api.serlo.org/graphql', { method: 'POST' })
     const response = (await api(req)) as Response
 
-    expect(await response.text()).toBe('<api-result>')
+    expect(await response.json()).toEqual({
+      data: { uuid: { username: 'inyono' } },
+    })
   })
 
   describe('returns null if subdomain is not "api"', () => {

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -279,10 +279,7 @@ describe('handleRequest()', () => {
   })
 
   test('returns null when type of path is unknown', async () => {
-    apiReturns({
-      errors: [{ message: 'error' }],
-      data: { uuid: null },
-    })
+    apiReturns({})
 
     const response = await handleUrl('https://de.serlo.org/unknown')
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -18,7 +18,7 @@ describe('handleRequest()', () => {
     global.FRONTEND_DOMAIN = 'frontend.serlo.org'
     global.API_ENDPOINT = 'https://api.serlo.org/'
     global.FRONTEND_SUPPORT_INTERNATIONALIZATION = 'false'
-
+    global.FRONTEND_ALLOWED_TYPES = '["Subject"]'
     global.FRONTEND_PROBABILITY = '0.5'
     Math.random = jest.fn().mockReturnValue(0.5)
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -4,8 +4,9 @@ import {
   expectHasOkStatus,
   mockHttpGet,
   returnText,
+  apiReturns,
   mockApi,
-  apiToReturnError,
+  returnMalformedJson,
 } from './_helper'
 
 enum Backend {
@@ -22,7 +23,7 @@ describe('handleRequest()', () => {
     global.FRONTEND_PROBABILITY = '0.5'
     Math.random = jest.fn().mockReturnValue(0.5)
 
-    mockApi({ __typename: 'Subject' })
+    apiReturns({ __typename: 'Subject' })
   })
 
   describe('chooses backend based on random number', () => {
@@ -141,7 +142,7 @@ describe('handleRequest()', () => {
         let response: Response
 
         beforeEach(async () => {
-          apiToReturnError()
+          mockApi(returnMalformedJson())
           mockHttpGet('https://de.serlo.org/math', returnText('content'))
 
           const request = new Request('https://de.serlo.org/math')
@@ -190,7 +191,7 @@ describe('handleRequest()', () => {
     let response: Response
 
     beforeEach(async () => {
-      apiToReturnError()
+      mockApi(returnMalformedJson())
       setupProbabilityFor(Backend.Frontend)
       mockHttpGet(url, returnText('content'))
 
@@ -271,7 +272,7 @@ describe('handleRequest()', () => {
 
   test('return null when type of path is not allowed', async () => {
     global.FRONTEND_ALLOWED_TYPES = '["Page", "Article"]'
-    mockApi({ __typename: 'TaxonomyTerm' })
+    apiReturns({ __typename: 'TaxonomyTerm' })
 
     const response = await handleUrl('https://de.serlo.org/42')
 
@@ -279,7 +280,7 @@ describe('handleRequest()', () => {
   })
 
   test('returns null when type of path is unknown', async () => {
-    mockApi({
+    apiReturns({
       errors: [{ message: 'error' }],
       data: { uuid: null },
     })
@@ -406,7 +407,7 @@ describe('handleRequest()', () => {
         'https://de.serlo.org/auth/hydra/consent',
         'https://de.serlo.org/user/register',
       ])('URL = %p', async (url) => {
-        apiToReturnError()
+        mockApi(returnMalformedJson())
         mockHttpGet(getUrlFor(Backend.Frontend, url), returnText('content'))
         mockHttpGet(getUrlFor(Backend.Legacy, url), returnText('content'))
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -22,7 +22,7 @@ describe('handleRequest()', () => {
     global.FRONTEND_PROBABILITY = '0.5'
     Math.random = jest.fn().mockReturnValue(0.5)
 
-    mockApi(global.API_ENDPOINT, { __typename: 'Subject' })
+    mockApi({ __typename: 'Subject' })
   })
 
   describe('chooses backend based on random number', () => {
@@ -141,7 +141,7 @@ describe('handleRequest()', () => {
         let response: Response
 
         beforeEach(async () => {
-          apiToReturnError(global.API_ENDPOINT)
+          apiToReturnError()
           mockHttpGet('https://de.serlo.org/math', returnText('content'))
 
           const request = new Request('https://de.serlo.org/math')
@@ -190,7 +190,7 @@ describe('handleRequest()', () => {
     let response: Response
 
     beforeEach(async () => {
-      apiToReturnError(global.API_ENDPOINT)
+      apiToReturnError()
       setupProbabilityFor(Backend.Frontend)
       mockHttpGet(url, returnText('content'))
 
@@ -271,7 +271,7 @@ describe('handleRequest()', () => {
 
   test('return null when type of path is not allowed', async () => {
     global.FRONTEND_ALLOWED_TYPES = '["Page", "Article"]'
-    mockApi(global.API_ENDPOINT, { __typename: 'TaxonomyTerm' })
+    mockApi({ __typename: 'TaxonomyTerm' })
 
     const response = await handleUrl('https://de.serlo.org/42')
 
@@ -279,7 +279,7 @@ describe('handleRequest()', () => {
   })
 
   test('returns null when type of path is unknown', async () => {
-    mockApi(global.API_ENDPOINT, {
+    mockApi({
       errors: [{ message: 'error' }],
       data: { uuid: null },
     })
@@ -406,7 +406,7 @@ describe('handleRequest()', () => {
         'https://de.serlo.org/auth/hydra/consent',
         'https://de.serlo.org/user/register',
       ])('URL = %p', async (url) => {
-        apiToReturnError(global.API_ENDPOINT)
+        apiToReturnError()
         mockHttpGet(getUrlFor(Backend.Frontend, url), returnText('content'))
         mockHttpGet(getUrlFor(Backend.Legacy, url), returnText('content'))
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -17,7 +17,6 @@ enum Backend {
 describe('handleRequest()', () => {
   beforeEach(() => {
     global.FRONTEND_DOMAIN = 'frontend.serlo.org'
-    global.API_ENDPOINT = 'https://api.serlo.org/'
     global.FRONTEND_SUPPORT_INTERNATIONALIZATION = 'false'
     global.FRONTEND_ALLOWED_TYPES = '["Subject"]'
     global.FRONTEND_PROBABILITY = '0.5'

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -1,6 +1,12 @@
 import { frontendProxy } from '../src/frontend-proxy'
 import { Instance } from '../src/utils'
-import { expectHasOkStatus, mockHttpGet, returnText, mockApi } from './_helper'
+import {
+  expectHasOkStatus,
+  mockHttpGet,
+  returnText,
+  mockApi,
+  apiToReturnError,
+} from './_helper'
 
 enum Backend {
   Frontend = 'frontend',
@@ -135,7 +141,7 @@ describe('handleRequest()', () => {
         let response: Response
 
         beforeEach(async () => {
-          apiToReturnError()
+          apiToReturnError(global.API_ENDPOINT)
           mockHttpGet('https://de.serlo.org/math', returnText('content'))
 
           const request = new Request('https://de.serlo.org/math')
@@ -184,7 +190,7 @@ describe('handleRequest()', () => {
     let response: Response
 
     beforeEach(async () => {
-      apiToReturnError()
+      apiToReturnError(global.API_ENDPOINT)
       setupProbabilityFor(Backend.Frontend)
       mockHttpGet(url, returnText('content'))
 
@@ -400,7 +406,7 @@ describe('handleRequest()', () => {
         'https://de.serlo.org/auth/hydra/consent',
         'https://de.serlo.org/user/register',
       ])('URL = %p', async (url) => {
-        apiToReturnError()
+        apiToReturnError(global.API_ENDPOINT)
         mockHttpGet(getUrlFor(Backend.Frontend, url), returnText('content'))
         mockHttpGet(getUrlFor(Backend.Legacy, url), returnText('content'))
 
@@ -558,10 +564,6 @@ describe('handleRequest()', () => {
 
 function setupProbabilityFor(backend: Backend) {
   global.FRONTEND_PROBABILITY = backend === Backend.Frontend ? '1' : '0'
-}
-
-function apiToReturnError() {
-  global.API_ENDPOINT, (_req, res, ctx) => res(ctx.status(404))
 }
 
 async function expectResponseFrom({

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -561,7 +561,7 @@ function setupProbabilityFor(backend: Backend) {
 }
 
 function apiToReturnError() {
-  mockApi(global.API_ENDPOINT, (_req, res, ctx) => res(ctx.status(404)))
+  global.API_ENDPOINT, (_req, res, ctx) => res(ctx.status(404))
 }
 
 async function expectResponseFrom({

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -25,8 +25,9 @@ import {
   mockKV,
   mockHttpGet,
   returnText,
+  apiReturns,
   mockApi,
-  apiToReturnMalformedJson,
+  returnMalformedJson,
 } from './_helper'
 
 describe('Enforce HTTPS', () => {
@@ -101,7 +102,7 @@ describe('Redirects', () => {
     })
 
     test('redirects when current path is different than given path', async () => {
-      mockApi({ __typename: 'Article', alias: '/current-path' })
+      apiReturns({ __typename: 'Article', alias: '/current-path' })
 
       const response = await handleUrl('https://en.serlo.org/path')
 
@@ -109,7 +110,7 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path is different than given path and XMLHttpRequest', async () => {
-      mockApi({ __typename: 'Article', alias: '/current-path' })
+      apiReturns({ __typename: 'Article', alias: '/current-path' })
 
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
@@ -124,7 +125,7 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path is the same as given path', async () => {
-      mockApi({ __typename: 'Article', alias: '/path' })
+      apiReturns({ __typename: 'Article', alias: '/path' })
 
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
@@ -134,7 +135,7 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path cannot be requested', async () => {
-      apiToReturnMalformedJson()
+      mockApi(returnMalformedJson())
 
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
@@ -145,7 +146,7 @@ describe('Redirects', () => {
 
     describe('handles URL encodings correctly', () => {
       test('API result is URL encoded', async () => {
-        mockApi({ __typename: 'Article', alias: '/gr%C3%B6%C3%9Fen' })
+        apiReturns({ __typename: 'Article', alias: '/gr%C3%B6%C3%9Fen' })
 
         mockHttpGet(
           'https://de.serlo.org/gr%C3%B6%C3%9Fen',
@@ -158,7 +159,7 @@ describe('Redirects', () => {
       })
 
       test('API result is not URL encoded', async () => {
-        mockApi({ __typename: 'Article', alias: '/größen' })
+        apiReturns({ __typename: 'Article', alias: '/größen' })
 
         mockHttpGet(
           'https://de.serlo.org/gr%C3%B6%C3%9Fen',
@@ -172,7 +173,7 @@ describe('Redirects', () => {
 
       test('API result is not URL encoded and cannot be decoded', async () => {
         mockHttpGet('https://de.serlo.org/%%x%%', returnText('article content'))
-        mockApi({ __typename: 'Article', alias: '/%%x%%' })
+        apiReturns({ __typename: 'Article', alias: '/%%x%%' })
 
         const response = await handleUrl('https://de.serlo.org/%%x%%')
 

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -21,13 +21,7 @@
  */
 
 import { handleRequest } from '../src'
-import {
-  mockKV,
-  mockHttpGet,
-  returnText,
-  mockHttpPost,
-  returnApiUuid,
-} from './_helper'
+import { mockKV, mockHttpGet, returnText, mockApi } from './_helper'
 
 describe('Enforce HTTPS', () => {
   test('HTTP URL', async () => {
@@ -101,10 +95,10 @@ describe('Redirects', () => {
     })
 
     test('redirects when current path is different than given path', async () => {
-      mockHttpPost(
-        'https://api.serlo.org/graphql',
-        returnApiUuid({ __typename: 'Article', alias: '/current-path' })
-      )
+      mockApi('https://api.serlo.org/graphql', {
+        __typename: 'Article',
+        alias: '/current-path',
+      })
 
       const response = await handleUrl('https://en.serlo.org/path')
 
@@ -112,10 +106,11 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path is different than given path and XMLHttpRequest', async () => {
-      mockHttpPost(
-        'https://api.serlo.org/graphql',
-        returnApiUuid({ __typename: 'Article', alias: '/current-path' })
-      )
+      mockApi('https://api.serlo.org/graphql', {
+        __typename: 'Article',
+        alias: '/current-path',
+      })
+
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
       const request = new Request('https://en.serlo.org/path', {
@@ -129,10 +124,11 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path is the same as given path', async () => {
-      mockHttpPost(
-        'https://api.serlo.org/graphql',
-        returnApiUuid({ __typename: 'Article', alias: '/path' })
-      )
+      mockApi('https://api.serlo.org/graphql', {
+        __typename: 'Article',
+        alias: '/path',
+      })
+
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
       const response = await handleUrl('https://en.serlo.org/path')
@@ -141,10 +137,8 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path cannot be requested', async () => {
-      mockHttpPost(
-        'https://api.serlo.org/graphql',
-        returnText('malformed json')
-      )
+      mockApi('https://api.serlo.org/graphql', returnText('malformed json'))
+
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
       const response = await handleUrl('https://en.serlo.org/path')
@@ -154,10 +148,11 @@ describe('Redirects', () => {
 
     describe('handles URL encodings correctly', () => {
       test('API result is URL encoded', async () => {
-        mockHttpPost(
-          'https://api.serlo.org/graphql',
-          returnApiUuid({ __typename: 'Article', alias: '/gr%C3%B6%C3%9Fen' })
-        )
+        mockApi('https://api.serlo.org/graphql', {
+          __typename: 'Article',
+          alias: '/gr%C3%B6%C3%9Fen',
+        })
+
         mockHttpGet(
           'https://de.serlo.org/gr%C3%B6%C3%9Fen',
           returnText('article content')
@@ -169,10 +164,11 @@ describe('Redirects', () => {
       })
 
       test('API result is not URL encoded', async () => {
-        mockHttpPost(
-          'https://api.serlo.org/graphql',
-          returnApiUuid({ __typename: 'Article', alias: '/größen' })
-        )
+        mockApi('https://api.serlo.org/graphql', {
+          __typename: 'Article',
+          alias: '/größen',
+        })
+
         mockHttpGet(
           'https://de.serlo.org/gr%C3%B6%C3%9Fen',
           returnText('article content')
@@ -185,10 +181,10 @@ describe('Redirects', () => {
 
       test('API result is not URL encoded and cannot be decoded', async () => {
         mockHttpGet('https://de.serlo.org/%%x%%', returnText('article content'))
-        mockHttpPost(
-          'https://api.serlo.org/graphql',
-          returnApiUuid({ __typename: 'Article', alias: '/%%x%%' })
-        )
+        mockApi('https://api.serlo.org/graphql', {
+          __typename: 'Article',
+          alias: '/%%x%%',
+        })
 
         const response = await handleUrl('https://de.serlo.org/%%x%%')
 

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -97,10 +97,6 @@ describe('Redirects', () => {
   })
 
   describe('redirects to current path of an resource', () => {
-    beforeEach(() => {
-      global.API_ENDPOINT = 'https://api.serlo.org/graphql'
-    })
-
     test('redirects when current path is different than given path', async () => {
       apiReturns({ __typename: 'Article', alias: '/current-path' })
 

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -21,7 +21,13 @@
  */
 
 import { handleRequest } from '../src'
-import { mockKV, mockHttpGet, returnText, mockApi } from './_helper'
+import {
+  mockKV,
+  mockHttpGet,
+  returnText,
+  mockApi,
+  apiToReturnMalformedJson,
+} from './_helper'
 
 describe('Enforce HTTPS', () => {
   test('HTTP URL', async () => {
@@ -95,10 +101,7 @@ describe('Redirects', () => {
     })
 
     test('redirects when current path is different than given path', async () => {
-      mockApi('https://api.serlo.org/graphql', {
-        __typename: 'Article',
-        alias: '/current-path',
-      })
+      mockApi({ __typename: 'Article', alias: '/current-path' })
 
       const response = await handleUrl('https://en.serlo.org/path')
 
@@ -106,10 +109,7 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path is different than given path and XMLHttpRequest', async () => {
-      mockApi('https://api.serlo.org/graphql', {
-        __typename: 'Article',
-        alias: '/current-path',
-      })
+      mockApi({ __typename: 'Article', alias: '/current-path' })
 
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
@@ -124,10 +124,7 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path is the same as given path', async () => {
-      mockApi('https://api.serlo.org/graphql', {
-        __typename: 'Article',
-        alias: '/path',
-      })
+      mockApi({ __typename: 'Article', alias: '/path' })
 
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
@@ -137,7 +134,7 @@ describe('Redirects', () => {
     })
 
     test('no redirect when current path cannot be requested', async () => {
-      mockApi('https://api.serlo.org/graphql', returnText('malformed json'))
+      apiToReturnMalformedJson()
 
       mockHttpGet('https://en.serlo.org/path', returnText('article content'))
 
@@ -148,10 +145,7 @@ describe('Redirects', () => {
 
     describe('handles URL encodings correctly', () => {
       test('API result is URL encoded', async () => {
-        mockApi('https://api.serlo.org/graphql', {
-          __typename: 'Article',
-          alias: '/gr%C3%B6%C3%9Fen',
-        })
+        mockApi({ __typename: 'Article', alias: '/gr%C3%B6%C3%9Fen' })
 
         mockHttpGet(
           'https://de.serlo.org/gr%C3%B6%C3%9Fen',
@@ -164,10 +158,7 @@ describe('Redirects', () => {
       })
 
       test('API result is not URL encoded', async () => {
-        mockApi('https://api.serlo.org/graphql', {
-          __typename: 'Article',
-          alias: '/größen',
-        })
+        mockApi({ __typename: 'Article', alias: '/größen' })
 
         mockHttpGet(
           'https://de.serlo.org/gr%C3%B6%C3%9Fen',
@@ -181,10 +172,7 @@ describe('Redirects', () => {
 
       test('API result is not URL encoded and cannot be decoded', async () => {
         mockHttpGet('https://de.serlo.org/%%x%%', returnText('article content'))
-        mockApi('https://api.serlo.org/graphql', {
-          __typename: 'Article',
-          alias: '/%%x%%',
-        })
+        mockApi({ __typename: 'Article', alias: '/%%x%%' })
 
         const response = await handleUrl('https://de.serlo.org/%%x%%')
 

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -46,9 +46,10 @@ import {
   mockKV,
   mockHttpGet,
   returnText,
+  apiReturns,
   mockApi,
-  apiToReturnMalformedJson,
-  apiToReturn,
+  returnMalformedJson,
+  returnJson,
 } from './_helper'
 
 describe('decodePath()', () => {
@@ -110,7 +111,7 @@ describe('getPathInfo()', () => {
   })
 
   test('returns typename and currentPath from api.serlo.org', async () => {
-    mockApi({ __typename: 'Article', alias: '/current-path' })
+    apiReturns({ __typename: 'Article', alias: '/current-path' })
 
     const pathInfo = await getPathInfo(Instance.En, '/path')
 
@@ -121,7 +122,7 @@ describe('getPathInfo()', () => {
   })
 
   test('"currentPath" is given path when it does not refer to an entity', async () => {
-    mockApi({ __typename: 'ArticleRevision' })
+    apiReturns({ __typename: 'ArticleRevision' })
 
     const pathInfo = await getPathInfo(Instance.En, '/path')
 
@@ -133,7 +134,7 @@ describe('getPathInfo()', () => {
 
   describe('when path describes a User', () => {
     test('when path is "/<id>"', async () => {
-      mockApi({ __typename: 'User', username: 'arekkas' })
+      apiReturns({ __typename: 'User', username: 'arekkas' })
 
       const pathInfo = await getPathInfo(Instance.En, '/1')
 
@@ -144,7 +145,7 @@ describe('getPathInfo()', () => {
     })
 
     test('when path is "/user/profile/id"', async () => {
-      mockApi({ __typename: 'User', username: 'arekkas' })
+      apiReturns({ __typename: 'User', username: 'arekkas' })
 
       const pathInfo = await getPathInfo(Instance.En, '/user/profile/1')
 
@@ -221,13 +222,13 @@ describe('getPathInfo()', () => {
 
   describe('returns null', () => {
     test('when there was an error with the api call', async () => {
-      mockApi(returnText('', { status: 403 }))
+      apiReturns(returnText('', { status: 403 }))
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
 
     test('when api response is malformed JSON', async () => {
-      apiToReturnMalformedJson()
+      mockApi(returnMalformedJson())
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
@@ -236,7 +237,7 @@ describe('getPathInfo()', () => {
       test.each([null, {}, { data: { uuid: {} } }])(
         'response = %p',
         async (response) => {
-          apiToReturn(response)
+          mockApi(returnJson(response))
 
           expect(await getPathInfo(Instance.En, '/path')).toBeNull()
         }
@@ -246,7 +247,7 @@ describe('getPathInfo()', () => {
 
   describe('when path is a course', () => {
     test('"currentPath" is path of first course page', async () => {
-      mockApi({
+      apiReturns({
         __typename: 'Course',
         alias: '/course',
         pages: [{ alias: '/course-page1' }, { alias: '/course-page2' }],
@@ -261,7 +262,7 @@ describe('getPathInfo()', () => {
     })
 
     test('"currentPath" is path of course when list of course pages is empty', async () => {
-      mockApi({
+      apiReturns({
         __typename: 'Course',
         alias: '/course',
         pages: [],
@@ -290,7 +291,7 @@ describe('getPathInfo()', () => {
     })
 
     test('saves values in cache for 1 hour', async () => {
-      mockApi({ __typename: 'Article', alias: '/current-path' })
+      apiReturns({ __typename: 'Article', alias: '/current-path' })
 
       await getPathInfo(Instance.En, '/path')
 
@@ -310,7 +311,7 @@ describe('getPathInfo()', () => {
         '%AE%BE%E0%AE%9F%E0%AF%81-%E0%AE%87%E0%AE%B2%E0%AE%95%E0%AF%8D%E0' +
         '%AE%95%E0%AE%BF%E0%AE%AF-%E0%AE%B5%E0%AE%95%E0%AF%88%E0%AE%95%E0' +
         '%AE%B3%E0%AF%8D'
-      mockApi({ __typename: 'Article', alias: longTamilPath })
+      apiReturns({ __typename: 'Article', alias: longTamilPath })
 
       await getPathInfo(Instance.Ta, longTamilPath)
 
@@ -324,7 +325,7 @@ describe('getPathInfo()', () => {
       const target = { typename: 'Article', currentPath: '/current-path' }
 
       beforeEach(() => {
-        mockApi({ __typename: 'Article', alias: '/current-path' })
+        apiReturns({ __typename: 'Article', alias: '/current-path' })
       })
 
       test('when cached value is malformed JSON', async () => {

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -20,7 +20,7 @@
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
 
-import { MockedRequest } from 'msw/lib/types'
+import { MockedRequest, rest } from 'msw/lib/types'
 import { h } from 'preact'
 
 import { Template } from '../src/ui'
@@ -204,20 +204,17 @@ describe('getPathInfo()', () => {
       lang = Instance.En
     ): Promise<MockedRequest> {
       let request!: MockedRequest
-      mockApi(apiEndpoint, (req, res, ctx) => {
-        request = req
-
-        return returnApiUuid({
-          __typename: 'Article',
-          alias: path,
-        })(req, res, ctx)
-      })
+      global.server.use(
+        rest.post(apiEndpoint, (_req, res, ctx) => {
+          return res(ctx.json({ data: {  __typename: 'Article',
+          alias: path } }))
+        })
+      )
 
       await getPathInfo(lang, path)
 
       return request
     }
-  })
 
   describe('returns null', () => {
     test('when there was an error with the api call', async () => {

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -50,6 +50,7 @@ import {
   mockApi,
   returnMalformedJson,
   returnJson,
+  returnBadRequest,
 } from './_helper'
 
 describe('decodePath()', () => {
@@ -221,7 +222,7 @@ describe('getPathInfo()', () => {
 
   describe('returns null', () => {
     test('when there was an error with the api call', async () => {
-      apiReturns(returnText('', { status: 403 }))
+      mockApi(returnBadRequest())
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -47,8 +47,7 @@ import {
   mockHttpGet,
   returnText,
   returnJson,
-  mockHttpPost,
-  returnApiUuid,
+  mockApi,
 } from './_helper'
 
 describe('decodePath()', () => {
@@ -110,10 +109,7 @@ describe('getPathInfo()', () => {
   })
 
   test('returns typename and currentPath from api.serlo.org', async () => {
-    mockHttpPost(
-      apiEndpoint,
-      returnApiUuid({ __typename: 'Article', alias: '/current-path' })
-    )
+    mockApi(apiEndpoint, { __typename: 'Article', alias: '/current-path' })
 
     const pathInfo = await getPathInfo(Instance.En, '/path')
 
@@ -124,7 +120,7 @@ describe('getPathInfo()', () => {
   })
 
   test('"currentPath" is given path when it does not refer to an entity', async () => {
-    mockHttpPost(apiEndpoint, returnApiUuid({ __typename: 'ArticleRevision' }))
+    mockApi(apiEndpoint, { __typename: 'ArticleRevision' })
 
     const pathInfo = await getPathInfo(Instance.En, '/path')
 
@@ -136,10 +132,7 @@ describe('getPathInfo()', () => {
 
   describe('when path describes a User', () => {
     test('when path is "/<id>"', async () => {
-      mockHttpPost(
-        apiEndpoint,
-        returnApiUuid({ __typename: 'User', username: 'arekkas' })
-      )
+      mockApi(apiEndpoint, { __typename: 'User', username: 'arekkas' })
 
       const pathInfo = await getPathInfo(Instance.En, '/1')
 
@@ -150,10 +143,7 @@ describe('getPathInfo()', () => {
     })
 
     test('when path is "/user/profile/id"', async () => {
-      mockHttpPost(
-        apiEndpoint,
-        returnApiUuid({ __typename: 'User', username: 'arekkas' })
-      )
+      mockApi(apiEndpoint, { __typename: 'User', username: 'arekkas' })
 
       const pathInfo = await getPathInfo(Instance.En, '/user/profile/1')
 
@@ -214,7 +204,7 @@ describe('getPathInfo()', () => {
       lang = Instance.En
     ): Promise<MockedRequest> {
       let request!: MockedRequest
-      mockHttpPost(apiEndpoint, (req, res, ctx) => {
+      mockApi(apiEndpoint, (req, res, ctx) => {
         request = req
 
         return returnApiUuid({
@@ -231,13 +221,13 @@ describe('getPathInfo()', () => {
 
   describe('returns null', () => {
     test('when there was an error with the api call', async () => {
-      mockHttpPost(apiEndpoint, returnText('', { status: 403 }))
+      mockApi(apiEndpoint, returnText('', { status: 403 }))
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
 
     test('when api response is malformed JSON', async () => {
-      mockHttpPost(apiEndpoint, returnText('malform json'))
+      mockApi(apiEndpoint, returnText('malform json'))
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
@@ -246,7 +236,7 @@ describe('getPathInfo()', () => {
       test.each([{}, { data: { uuid: {} } }])(
         'response = %p',
         async (response) => {
-          mockHttpPost(apiEndpoint, returnJson(response))
+          mockApi(apiEndpoint, returnJson(response))
 
           expect(await getPathInfo(Instance.En, '/path')).toBeNull()
         }
@@ -256,14 +246,11 @@ describe('getPathInfo()', () => {
 
   describe('when path is a course', () => {
     test('"currentPath" is path of first course page', async () => {
-      mockHttpPost(
-        apiEndpoint,
-        returnApiUuid({
-          __typename: 'Course',
-          alias: '/course',
-          pages: [{ alias: '/course-page1' }, { alias: '/course-page2' }],
-        })
-      )
+      mockApi(apiEndpoint, {
+        __typename: 'Course',
+        alias: '/course',
+        pages: [{ alias: '/course-page1' }, { alias: '/course-page2' }],
+      })
 
       const pathInfo = await getPathInfo(Instance.En, '/course')
 
@@ -274,10 +261,11 @@ describe('getPathInfo()', () => {
     })
 
     test('"currentPath" is path of course when list of course pages is empty', async () => {
-      mockHttpPost(
-        apiEndpoint,
-        returnApiUuid({ __typename: 'Course', alias: '/course', pages: [] })
-      )
+      mockApi(apiEndpoint, {
+        __typename: 'Course',
+        alias: '/course',
+        pages: [],
+      })
 
       const pathInfo = await getPathInfo(Instance.En, '/course')
 
@@ -302,10 +290,7 @@ describe('getPathInfo()', () => {
     })
 
     test('saves values in cache for 1 hour', async () => {
-      mockHttpPost(
-        apiEndpoint,
-        returnApiUuid({ __typename: 'Article', alias: '/current-path' })
-      )
+      mockApi(apiEndpoint, { __typename: 'Article', alias: '/current-path' })
 
       await getPathInfo(Instance.En, '/path')
 
@@ -325,10 +310,7 @@ describe('getPathInfo()', () => {
         '%AE%BE%E0%AE%9F%E0%AF%81-%E0%AE%87%E0%AE%B2%E0%AE%95%E0%AF%8D%E0' +
         '%AE%95%E0%AE%BF%E0%AE%AF-%E0%AE%B5%E0%AE%95%E0%AF%88%E0%AE%95%E0' +
         '%AE%B3%E0%AF%8D'
-      mockHttpPost(
-        apiEndpoint,
-        returnApiUuid({ __typename: 'Article', alias: longTamilPath })
-      )
+      mockApi(apiEndpoint, { __typename: 'Article', alias: longTamilPath })
 
       await getPathInfo(Instance.Ta, longTamilPath)
 
@@ -342,10 +324,7 @@ describe('getPathInfo()', () => {
       const target = { typename: 'Article', currentPath: '/current-path' }
 
       beforeEach(() => {
-        mockHttpPost(
-          apiEndpoint,
-          returnApiUuid({ __typename: 'Article', alias: '/current-path' })
-        )
+        mockApi(apiEndpoint, { __typename: 'Article', alias: '/current-path' })
       })
 
       test('when cached value is malformed JSON', async () => {

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -109,7 +109,7 @@ describe('getPathInfo()', () => {
   })
 
   test('returns typename and currentPath from api.serlo.org', async () => {
-    mockApi(apiEndpoint, { __typename: 'Article', alias: '/current-path' })
+    mockApi({ __typename: 'Article', alias: '/current-path' })
 
     const pathInfo = await getPathInfo(Instance.En, '/path')
 
@@ -120,7 +120,7 @@ describe('getPathInfo()', () => {
   })
 
   test('"currentPath" is given path when it does not refer to an entity', async () => {
-    mockApi(apiEndpoint, { __typename: 'ArticleRevision' })
+    mockApi({ __typename: 'ArticleRevision' })
 
     const pathInfo = await getPathInfo(Instance.En, '/path')
 
@@ -132,7 +132,7 @@ describe('getPathInfo()', () => {
 
   describe('when path describes a User', () => {
     test('when path is "/<id>"', async () => {
-      mockApi(apiEndpoint, { __typename: 'User', username: 'arekkas' })
+      mockApi({ __typename: 'User', username: 'arekkas' })
 
       const pathInfo = await getPathInfo(Instance.En, '/1')
 
@@ -143,7 +143,7 @@ describe('getPathInfo()', () => {
     })
 
     test('when path is "/user/profile/id"', async () => {
-      mockApi(apiEndpoint, { __typename: 'User', username: 'arekkas' })
+      mockApi({ __typename: 'User', username: 'arekkas' })
 
       const pathInfo = await getPathInfo(Instance.En, '/user/profile/1')
 
@@ -218,13 +218,14 @@ describe('getPathInfo()', () => {
 
   describe('returns null', () => {
     test('when there was an error with the api call', async () => {
-      mockApi(apiEndpoint, returnText('', { status: 403 }))
+      mockApi(returnText('', { status: 403 }))
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
 
     test('when api response is malformed JSON', async () => {
-      mockApi(apiEndpoint, returnText('malform json'))
+      mockApi(returnText('malform json'))
+      apiToReturnMalformedJson()
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
@@ -233,7 +234,7 @@ describe('getPathInfo()', () => {
       test.each([{}, { data: { uuid: {} } }])(
         'response = %p',
         async (response) => {
-          mockApi(apiEndpoint, returnJson(response))
+          mockApi(returnJson(response))
 
           expect(await getPathInfo(Instance.En, '/path')).toBeNull()
         }
@@ -243,7 +244,7 @@ describe('getPathInfo()', () => {
 
   describe('when path is a course', () => {
     test('"currentPath" is path of first course page', async () => {
-      mockApi(apiEndpoint, {
+      mockApi({
         __typename: 'Course',
         alias: '/course',
         pages: [{ alias: '/course-page1' }, { alias: '/course-page2' }],
@@ -258,7 +259,7 @@ describe('getPathInfo()', () => {
     })
 
     test('"currentPath" is path of course when list of course pages is empty', async () => {
-      mockApi(apiEndpoint, {
+      mockApi({
         __typename: 'Course',
         alias: '/course',
         pages: [],
@@ -287,7 +288,7 @@ describe('getPathInfo()', () => {
     })
 
     test('saves values in cache for 1 hour', async () => {
-      mockApi(apiEndpoint, { __typename: 'Article', alias: '/current-path' })
+      mockApi({ __typename: 'Article', alias: '/current-path' })
 
       await getPathInfo(Instance.En, '/path')
 
@@ -307,7 +308,7 @@ describe('getPathInfo()', () => {
         '%AE%BE%E0%AE%9F%E0%AF%81-%E0%AE%87%E0%AE%B2%E0%AE%95%E0%AF%8D%E0' +
         '%AE%95%E0%AE%BF%E0%AE%AF-%E0%AE%B5%E0%AE%95%E0%AF%88%E0%AE%95%E0' +
         '%AE%B3%E0%AF%8D'
-      mockApi(apiEndpoint, { __typename: 'Article', alias: longTamilPath })
+      mockApi({ __typename: 'Article', alias: longTamilPath })
 
       await getPathInfo(Instance.Ta, longTamilPath)
 
@@ -321,7 +322,7 @@ describe('getPathInfo()', () => {
       const target = { typename: 'Article', currentPath: '/current-path' }
 
       beforeEach(() => {
-        mockApi(apiEndpoint, { __typename: 'Article', alias: '/current-path' })
+        mockApi({ __typename: 'Article', alias: '/current-path' })
       })
 
       test('when cached value is malformed JSON', async () => {

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -48,6 +48,8 @@ import {
   returnText,
   returnJson,
   mockApi,
+  apiToReturnMalformedJson,
+  apiToReturnEmptyJson,
 } from './_helper'
 
 describe('decodePath()', () => {
@@ -224,8 +226,8 @@ describe('getPathInfo()', () => {
     })
 
     test('when api response is malformed JSON', async () => {
-      mockApi(returnText('malform json'))
-      apiToReturnMalformedJson()
+      apiToReturnMalformedJson('malform json')
+      
 
       expect(await getPathInfo(Instance.En, '/path')).toBeNull()
     })
@@ -234,7 +236,7 @@ describe('getPathInfo()', () => {
       test.each([{}, { data: { uuid: {} } }])(
         'response = %p',
         async (response) => {
-          mockApi(returnJson(response))
+          apiToReturnEmptyJson(response)
 
           expect(await getPathInfo(Instance.En, '/path')).toBeNull()
         }

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -104,8 +104,6 @@ describe('getCookieValue()', () => {
 })
 
 describe('getPathInfo()', () => {
-  const apiEndpoint = 'https://api.serlo.org/graphql'
-
   beforeEach(() => {
     mockKV('PATH_INFO_KV', {})
   })
@@ -208,7 +206,7 @@ describe('getPathInfo()', () => {
       let request!: MockedRequest
 
       global.server.use(
-        rest.post(apiEndpoint, (req, res, ctx) => {
+        rest.post(global.API_ENDPOINT, (req, res, ctx) => {
           request = req
           return res(ctx.json({ data: { __typename: 'Article', alias: path } }))
         })
@@ -262,11 +260,7 @@ describe('getPathInfo()', () => {
     })
 
     test('"currentPath" is path of course when list of course pages is empty', async () => {
-      apiReturns({
-        __typename: 'Course',
-        alias: '/course',
-        pages: [],
-      })
+      apiReturns({ __typename: 'Course', alias: '/course', pages: [] })
 
       const pathInfo = await getPathInfo(Instance.En, '/course')
 

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -106,7 +106,6 @@ describe('getPathInfo()', () => {
   const apiEndpoint = 'https://api.serlo.org/graphql'
 
   beforeEach(() => {
-    global.API_ENDPOINT = apiEndpoint
     mockKV('PATH_INFO_KV', {})
   })
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -39,7 +39,7 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  global.API_ENDPOINT = 'https://api.serlo.org'
+  global.API_ENDPOINT = 'https://api.serlo.org/graphql'
   global.API_SECRET = 'secret'
   global.FRONTEND_DOMAIN = 'frontend.serlo.org'
   global.FRONTEND_PROBABILITY = '1'


### PR DESCRIPTION
I tried to comment on the code but it somehow doesnt allow me 
on Frontend-proxy.ts
Line 563 : function apiToReturnError() {
  mockApi(global.API_ENDPOINT, (_req, res, ctx) => res(ctx.status(404)))
}

My thinking was to change the mockApi function in the helper and add a "|| resolver" so that the function as it is written can work. 
and in utils.tsx
line 262:
i tried to create a apiUuid function that was similar to the returnUuid and which takes Mockedrequest as first argument and Uuid as second