### PR TITLE
No redirect for /spenden 

### DIFF
--- a/__tests__/__utils__/index.ts
+++ b/__tests__/__utils__/index.ts
@@ -23,3 +23,12 @@
 export * from './expect-helper'
 export * from './kv'
 export * from './services'
+
+export enum Backend {
+  Frontend = 'frontend',
+  Legacy = 'legacy',
+}
+
+export function setupProbabilityFor(backend: Backend) {
+  global.FRONTEND_PROBABILITY = backend === Backend.Frontend ? '1' : '0'
+}

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -117,6 +117,15 @@ describe('handleRequest()', () => {
       })
     })
 
+    test('prepends language prefix for special path /spenden', async () => {
+      setupProbabilityFor(Backend.Frontend)
+
+      await expectResponseFrom({
+        backend: 'https://frontend.serlo.org/en/spenden',
+        request: 'https://en.serlo.org/spenden',
+      })
+    })
+
     test('removes trailing slashes from the frontend url', async () => {
       setupProbabilityFor(Backend.Frontend)
 
@@ -128,7 +137,6 @@ describe('handleRequest()', () => {
 
     describe('special paths do not get a language prefix', () => {
       test.each([
-        'https://de.serlo.org/spenden',
         'https://de.serlo.org/_next/script.js',
         'https://de.serlo.org/_assets/image.png',
         'https://de.serlo.org/api/frontend/privacy',
@@ -182,16 +190,6 @@ describe('handleRequest()', () => {
 
         test('does not set cookie with random number', () => {
           expect(response.headers.get('Set-Cookie')).toBeNull()
-        })
-      })
-
-      test('/spenden go to legacy backend', async () => {
-        const request = new Request('https://de.serlo.org/spenden')
-        request.headers.set('Cookie', 'authenticated=1')
-
-        await expectResponseFrom({
-          backend: 'https://de.serlo.org/spenden',
-          request,
         })
       })
     })
@@ -350,31 +348,38 @@ describe('handleRequest()', () => {
       })
     })
 
-    test('requests to /spenden always resolve to frontend', async () => {
-      await expectResponseFrom({
-        backend: 'https://frontend.serlo.org/spenden',
-        request: 'https://de.serlo.org/spenden',
-      })
-    })
-
     describe('special paths where the cookie determines the backend', () => {
-      describe.each(['https://de.serlo.org/search', 'https://de.serlo.org/'])(
-        'URL = %p',
-        (url) => {
-          test.each([Backend.Frontend, Backend.Legacy])(
-            'backend = %p',
-            async (backend) => {
-              setupProbabilityFor(backend)
-              Math.random = jest.fn().mockReturnValue(0.5)
+      describe.each([
+        'https://de.serlo.org/',
+        'https://de.serlo.org/search',
+        'https://de.serlo.org/spenden',
+      ])('URL = %p', (url) => {
+        test.each([Backend.Frontend, Backend.Legacy])(
+          'backend = %p',
+          async (backend) => {
+            // Make sure that there is no redirect before the frontend is
+            // resolved
+            givenUuid({
+              __typename: 'Page',
+              oldAlias: '/spenden',
+              alias: '/21565/spenden',
+            })
+            givenUuid({
+              __typename: 'Page',
+              oldAlias: '/search',
+              alias: '/21565/spenden',
+            })
 
-              await expectResponseFrom({
-                backend: getUrlFor(backend, url),
-                request: url,
-              })
-            }
-          )
-        }
-      )
+            setupProbabilityFor(backend)
+            Math.random = jest.fn().mockReturnValue(0.5)
+
+            await expectResponseFrom({
+              backend: getUrlFor(backend, url),
+              request: url,
+            })
+          }
+        )
+      })
     })
 
     describe('forwards authentication requests to legacy backend', () => {
@@ -438,7 +443,6 @@ describe('handleRequest()', () => {
 
     describe('Predetermined special paths do not set a cookie', () => {
       test.each([
-        'https://de.serlo.org/spenden',
         'https://de.serlo.org/_next/script.js',
         'https://de.serlo.org/_assets/image.png',
         'https://de.serlo.org/api/frontend/privacy',

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -29,12 +29,9 @@ import {
   givenApi,
   returnsMalformedJson,
   returnsJson,
+  Backend,
+  setupProbabilityFor,
 } from './__utils__'
-
-export enum Backend {
-  Frontend = 'frontend',
-  Legacy = 'legacy',
-}
 
 describe('handleRequest()', () => {
   beforeEach(() => {
@@ -570,10 +567,6 @@ describe('handleRequest()', () => {
     })
   })
 })
-
-export function setupProbabilityFor(backend: Backend) {
-  global.FRONTEND_PROBABILITY = backend === Backend.Frontend ? '1' : '0'
-}
 
 async function expectResponseFrom({
   backend,

--- a/__tests__/maintenance.ts
+++ b/__tests__/maintenance.ts
@@ -28,8 +28,9 @@ import {
   mockKV,
   mockHttpGet,
   returnsText,
+  setupProbabilityFor,
+  Backend,
 } from './__utils__'
-import { setupProbabilityFor, Backend } from './frontend-proxy'
 
 describe('Maintenance mode', () => {
   beforeEach(() => {

--- a/__tests__/static-pages.tsx
+++ b/__tests__/static-pages.tsx
@@ -49,8 +49,9 @@ import {
   mockHttpGet,
   returnsText,
   hasInternalServerError,
+  setupProbabilityFor,
+  Backend,
 } from './__utils__'
-import { setupProbabilityFor, Backend } from './frontend-proxy'
 
 describe('handleRequest()', () => {
   const unrevisedConfig: UnrevisedConfig = {

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -21,6 +21,8 @@
  */
 import { Url, getCookieValue, isInstance, Instance, getPathInfo } from './utils'
 
+export const specialPaths = ['/', '/search', '/spenden']
+
 export async function frontendSpecialPaths(
   request: Request
 ): Promise<Response | null> {
@@ -76,10 +78,7 @@ export async function frontendProxy(
   )
     return await fetchBackend({ ...config, useFrontend: false, request })
 
-  if (url.pathname === '/spenden')
-    return await fetchBackend({ ...config, useFrontend: true, request })
-
-  if (url.pathname !== '/' && url.pathname !== '/search') {
+  if (!specialPaths.includes(url.pathname)) {
     const pathInfo = await getPathInfo(config.instance, url.pathname)
     const typename = pathInfo?.typename ?? null
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,11 @@
 import { api } from './api'
 import { edtrIoStats } from './are-we-edtr-io-yet'
 import { authFrontendSectorIdentifierUriValidation } from './auth'
-import { frontendProxy, frontendSpecialPaths } from './frontend-proxy'
+import {
+  frontendProxy,
+  frontendSpecialPaths,
+  specialPaths,
+} from './frontend-proxy'
 import { maintenanceMode } from './maintenance'
 import { staticPages } from './static-pages'
 import { Url, getPathInfo, isInstance, Instance } from './utils'
@@ -99,7 +103,7 @@ async function redirects(request: Request) {
     return url.toRedirect()
   }
 
-  if (isInstance(url.subdomain)) {
+  if (isInstance(url.subdomain) && !specialPaths.includes(url.pathname)) {
     const pathInfo = await getPathInfo(url.subdomain, url.pathname)
     if (
       request.headers.get('X-Requested-With') !== 'XMLHttpRequest' &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,12 +22,12 @@
 import { api } from './api'
 import { edtrIoStats } from './are-we-edtr-io-yet'
 import { authFrontendSectorIdentifierUriValidation } from './auth'
+import { embed } from './embed'
 import {
   frontendProxy,
   frontendSpecialPaths,
   specialPaths,
 } from './frontend-proxy'
-import { embed } from './embed'
 import { maintenanceMode } from './maintenance'
 import { staticPages } from './static-pages'
 import {


### PR DESCRIPTION
Resolves the bug that `/spenden` is redirecting to `/21565/spenden` because there is still an old page. Due to the new alias system a redirect would be triggered. It also implements the logic that `/spenden` is treated like `/search` (where the cookie determines the backend).