### PR TITLE
WIP: Preview images via embed.serlo.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ The following variables define the behavior:
 - `FRONTEND_PROBABILITY`: The percentage of user which shall be redirected to the new frontend.
 
 With the cookie `frontendDomain` you can override the variable of `FRONTEND_DOMAIN`.
+
+## Preview Images
+
+Via `embed.serlo.org/thumbnail?url=${videoUrl|appletUrl}` you can request thumbnail images for supported providers (YouTube, Vimeo, Wikimedia Commons and Geogebra).

--- a/__tests__/embed.ts
+++ b/__tests__/embed.ts
@@ -24,28 +24,22 @@ import { mockHttpGet } from './__utils__'
 
 describe('embed.serlo.org/thumbnail?url=...', () => {
   test('returns placeholder png for empty requests', async () => {
-    const response = await handleRequest(
-      new Request('https://embed.serlo.org/thumbnail?url=')
-    )
+    const response = await requestThumbnail('')
 
     expect(response.headers.get('content-type')).toBe('image/png')
     expect(response.headers.get('content-length')).toBe('135')
   })
 
   test('returns placeholder png for unsupported urls', async () => {
-    const response = await handleRequest(
-      new Request(
-        `https://embed.serlo.org/thumbnail?url=${encodeURIComponent(
-          'https://www.twitch.tv/videos/824398155'
-        )}`
-      )
+    const response = await requestThumbnail(
+      'https://www.twitch.tv/videos/824398155'
     )
 
     expect(response.headers.get('content-type')).toBe('image/png')
     expect(response.headers.get('content-length')).toBe('135')
   })
 
-  test('returns thumbnail from youtube when url = https://www.youtube.com/watch?v=KtV2wlp9Ts4', async () => {
+  test('returns thumbnail from youtube when url is youtube url', async () => {
     mockHttpGet(
       'https://i.ytimg.com/vi/KtV2wlp9Ts4/hqdefault.jpg',
       (_req, res, ctx) => {
@@ -56,15 +50,18 @@ describe('embed.serlo.org/thumbnail?url=...', () => {
       }
     )
 
-    const response = await handleRequest(
-      new Request(
-        `https://embed.serlo.org/thumbnail?url=${encodeURIComponent(
-          'https://www.youtube.com/watch?v=KtV2wlp9Ts4'
-        )}`
-      )
+    const response = await requestThumbnail(
+      'https://www.youtube.com/watch?v=KtV2wlp9Ts4'
     )
 
     expect(response.headers.get('content-type')).toBe('image/jpeg')
     expect(response.headers.get('content-length')).toBe('11464')
   })
 })
+
+function requestThumbnail(url: string): Promise<Response> {
+  const requestUrl =
+    'https://embed.serlo.org/thumbnail?url=' + encodeURIComponent(url)
+
+  return handleRequest(new Request(requestUrl))
+}

--- a/__tests__/embed.ts
+++ b/__tests__/embed.ts
@@ -20,9 +20,31 @@
  * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
  */
 import { handleRequest } from '../src'
-import {mockHttpGet} from './__utils__'
+import { mockHttpGet } from './__utils__'
 
 describe('embed.serlo.org/thumbnail?url=...', () => {
+  test('returns placeholder png for empty requests', async () => {
+    const response = await handleRequest(
+      new Request('https://embed.serlo.org/thumbnail?url=')
+    )
+
+    expect(response.headers.get('content-type')).toBe('image/png')
+    expect(response.headers.get('content-length')).toBe('135')
+  })
+
+  test('returns placeholder png for unsupported urls', async () => {
+    const response = await handleRequest(
+      new Request(
+        `https://embed.serlo.org/thumbnail?url=${encodeURIComponent(
+          'https://www.twitch.tv/videos/824398155'
+        )}`
+      )
+    )
+
+    expect(response.headers.get('content-type')).toBe('image/png')
+    expect(response.headers.get('content-length')).toBe('135')
+  })
+
   test('returns thumbnail from youtube when url = https://www.youtube.com/watch?v=KtV2wlp9Ts4', async () => {
     mockHttpGet(
       'https://i.ytimg.com/vi/KtV2wlp9Ts4/hqdefault.jpg',
@@ -36,7 +58,7 @@ describe('embed.serlo.org/thumbnail?url=...', () => {
 
     const response = await handleRequest(
       new Request(
-        `https://embed.serlo.org/thumbnail?url= ${encodeURIComponent(
+        `https://embed.serlo.org/thumbnail?url=${encodeURIComponent(
           'https://www.youtube.com/watch?v=KtV2wlp9Ts4'
         )}`
       )

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,0 +1,62 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2020 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2020 Serlo Education e.V.
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo-org/serlo.org-cloudflare-worker for the canonical source repository
+ */
+import { Url } from './utils'
+
+export async function embed(request: Request): Promise<Response | null> {
+  const url = Url.fromRequest(request)
+
+  if (url.subdomain !== 'embed') return null
+
+  // embed.serlo.org/thumbnail?url=...
+
+  const urlParam = url.searchParams.get('url')
+
+  // TODO
+  if (urlParam === null || urlParam === '') return returnPlaceholder()
+
+  const videoUrl = new Url(urlParam)
+
+  if (videoUrl.domain === 'youtube.com') {
+    const vParam = videoUrl.searchParams.get('v')
+
+    // TODO
+    if (vParam === null) return null
+
+    return await fetch(`https://i.ytimg.com/vi/${vParam}/hqdefault.jpg`)
+  }
+
+  return returnPlaceholder()
+}
+
+function returnPlaceholder() {
+  const placeholderB64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAwAAAAGwAQMAAAAkGpCRAAAAA1BMVEXv9/t0VvapAAAAP0lEQVR42u3BMQEAAADCIPuntsUuYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOqOwAAHrgHqAAAAAAElFTkSuQmCC'
+  const buffer = Buffer.from(placeholderB64, 'base64')
+  return new Response(buffer, {
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Length': Buffer.byteLength(buffer).toString(),
+    },
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export async function handleRequest(request: Request) {
     (await enforceHttps(request)) ||
     (await frontendSpecialPaths(request)) ||
     (await redirects(request)) ||
+    (await embed(request)) ||
     (await staticPages(request)) ||
     (await semanticFileNames(request)) ||
     (await packages(request)) ||
@@ -47,6 +48,32 @@ export async function handleRequest(request: Request) {
     (await frontendProxy(request)) ||
     (await fetch(request))
   )
+}
+
+async function embed(request: Request): Promise<Response | null> {
+  const url = Url.fromRequest(request)
+
+  if (url.subdomain !== "embed") return null
+
+  // embed.serlo.org/thumbnail?url=...
+
+  const urlParam = url.searchParams.get("url")
+
+  // TODO
+  if (urlParam === null) return null
+
+  const videoUrl = new Url(urlParam)
+
+  if (videoUrl.domain === "youtube.com") {
+    const vParam = videoUrl.searchParams.get("v")
+
+    // TODO
+    if (vParam === null) return null
+
+    return await fetch(`https://i.ytimg.com/vi/${vParam}/hqdefault.jpg`)
+  }
+
+  return null
 }
 
 async function enforceHttps(request: Request) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@
 import { api } from './api'
 import { edtrIoStats } from './are-we-edtr-io-yet'
 import { authFrontendSectorIdentifierUriValidation } from './auth'
+import { embed } from './embed'
 import { frontendProxy, frontendSpecialPaths } from './frontend-proxy'
 import { maintenanceMode } from './maintenance'
 import { staticPages } from './static-pages'
@@ -48,32 +49,6 @@ export async function handleRequest(request: Request) {
     (await frontendProxy(request)) ||
     (await fetch(request))
   )
-}
-
-async function embed(request: Request): Promise<Response | null> {
-  const url = Url.fromRequest(request)
-
-  if (url.subdomain !== "embed") return null
-
-  // embed.serlo.org/thumbnail?url=...
-
-  const urlParam = url.searchParams.get("url")
-
-  // TODO
-  if (urlParam === null) return null
-
-  const videoUrl = new Url(urlParam)
-
-  if (videoUrl.domain === "youtube.com") {
-    const vParam = videoUrl.searchParams.get("v")
-
-    // TODO
-    if (vParam === null) return null
-
-    return await fetch(`https://i.ytimg.com/vi/${vParam}/hqdefault.jpg`)
-  }
-
-  return null
 }
 
 async function enforceHttps(request: Request) {


### PR DESCRIPTION
@kulla what do you think of the inline image code solution? Seemed nicer that to store image assets in the worker.
Other options include
- storing the placeholder in the frontend (redirecting the request to the frontend)
- or returning an error header and letting the frontend decide how to handle missing images.

Merge whenever you want.

(issue: #66)