### PR TITLE
Add eslint rule "no-console"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     // eslint
     'no-duplicate-imports': 'error',
     'no-unused-vars': 'off',
+    'no-console': 'error',
 
     // @typescript-eslint/eslint-plugin
     '@typescript-eslint/ban-ts-comment': 'warn',

--- a/scripts/maintenance.ts
+++ b/scripts/maintenance.ts
@@ -23,6 +23,7 @@ import { DateTime } from 'luxon'
 
 exec()
 
+/* eslint-disable no-console */
 function exec() {
   if (process.argv.length <= 2) {
     console.error('Expecting date')
@@ -49,3 +50,4 @@ function exec() {
     })
   }
 }
+/* eslint-enable no-console */


### PR DESCRIPTION
See https://eslint.org/docs/rules/no-console: So we can detect leftover console log statements before merging into master. `scripts/maintenance.ts` seems to be a legacy script with no purpose which I want to delete in a follow-up PR.