### PR TITLE
Add caching setting when fetching Wikimedia thumbnails

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -149,7 +149,9 @@ async function getGeogebraThumbnail(url: URL) {
 
     const thumbnailUrl = data.value.responses.response.item.previewUrl
 
-    const imgRes = await fetch(thumbnailUrl)
+    const imgRes = await fetch(thumbnailUrl, {
+      cf: { cacheTtl: 24 * 60 * 60, cacheEveything: true },
+    } as unknown as RequestInit)
     if (isImageResponse(imgRes)) return imgRes
   } catch (e) {
     // JSON cannot be parsed or preview url cannot be parsed


### PR DESCRIPTION
Currently wikimedia thumbnails like http://localhost:8787/thumbnail?url=https://upload.wikimedia.org/wikipedia/commons/1/15/Inerter_vibration_isolation_experiment.webm cannot be loaded since wikimedia responses with `429 Too many requests`. I add cache setting to see whether it helps... 