### PR TITLE
Fix assets tests: Use header "x-goog-stored-content-length"

### DIFF
--- a/__tests__/__utils__/expect-helper.ts
+++ b/__tests__/__utils__/expect-helper.ts
@@ -67,42 +67,6 @@ export function expectToBeRedirectTo(
   expect(response.status).toBe(status)
 }
 
-export function expectImageReponse({
-  expectedContentLength,
-  expectedImageType,
-  response,
-}: {
-  expectedImageType: string
-  expectedContentLength: number
-  response: Response
-}) {
-  expectHasOkStatus(response)
-  expect(response.headers.get('content-type')).toBe(expectedImageType)
-  expect(response.headers.get('content-length')).toBe(
-    expectedContentLength.toString()
-  )
-}
-
-export function expectImageResponseWithError({
-  expectedContentLength,
-  expectedImageType,
-  response,
-  maxRelativeError = 0.1,
-}: {
-  expectedImageType: string
-  expectedContentLength: number
-  response: Response
-  maxRelativeError?: number
-}) {
-  expectHasOkStatus(response)
-  expect(response.headers.get('content-type')).toBe(expectedImageType)
-  const contentLength = parseInt(response.headers.get('content-length') ?? '')
-
-  expect(
-    Math.abs(contentLength - expectedContentLength) / expectedContentLength
-  ).toBeLessThanOrEqual(maxRelativeError)
-}
-
 export function expectSentryEvent({
   message,
   level,

--- a/__tests__/__utils__/expect-helper.ts
+++ b/__tests__/__utils__/expect-helper.ts
@@ -34,15 +34,9 @@ export function expectContentTypeIsHtml(response: Response): void {
   expect(response.headers.get('Content-Type')).toBe('text/html;charset=utf-8')
 }
 
-export function expectHasOkStatus(response: Response): void {
-  expect(response).not.toBeNull()
-  expect(response.status).toBe(200)
-}
-
 export async function expectIsNotFoundResponse(
   response: Response
 ): Promise<void> {
-  expect(response).not.toBeNull()
   expect(response.status).toBe(404)
   expect(await response.text()).toEqual(
     expect.stringContaining('Page not found')
@@ -53,7 +47,7 @@ export async function expectIsJsonResponse(
   response: Response,
   targetJson: unknown
 ) {
-  expectHasOkStatus(response)
+  expect(response.status).toBe(200)
   expect(response.headers.get('Content-Type')).toBe('application/json')
   expect(JSON.parse(await response.text())).toEqual(targetJson)
 }

--- a/__tests__/embed.ts
+++ b/__tests__/embed.ts
@@ -30,8 +30,6 @@ import {
   returnsText,
   currentTestEnvironment,
   localTestEnvironment,
-  expectImageResponseWithError,
-  expectImageReponse,
   expectSentryEvent,
   expectNoSentryError,
 } from './__utils__'
@@ -532,11 +530,9 @@ describe('embed.serlo.org/thumbnail?url=...', () => {
 })
 
 function expectIsPlaceholderResponse(response: Response) {
-  expectImageReponse({
-    response,
-    expectedImageType: 'image/png',
-    expectedContentLength: 135,
-  })
+  expect(response.status).toBe(200)
+  expect(response.headers.get('content-type')).toBe('image/png')
+  expect(response.headers.get('content-length')).toBe('135')
 }
 
 async function requestThumbnail(
@@ -547,4 +543,24 @@ async function requestThumbnail(
     subdomain: 'embed',
     pathname: '/thumbnail?url=' + encodeURIComponent(url),
   })
+}
+
+function expectImageResponseWithError({
+  expectedContentLength,
+  expectedImageType,
+  response,
+  maxRelativeError = 0.1,
+}: {
+  expectedImageType: string
+  expectedContentLength: number
+  response: Response
+  maxRelativeError?: number
+}) {
+  expect(response.status).toBe(200)
+  expect(response.headers.get('content-type')).toBe(expectedImageType)
+  const contentLength = parseInt(response.headers.get('content-length') ?? '')
+
+  expect(
+    Math.abs(contentLength - expectedContentLength) / expectedContentLength
+  ).toBeLessThanOrEqual(maxRelativeError)
 }

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -21,7 +21,6 @@
  */
 import { Instance } from '../src/utils'
 import {
-  expectHasOkStatus,
   mockHttpGet,
   returnsText,
   givenUuid,
@@ -574,7 +573,7 @@ describe('requests to /enable-frontend enable use of frontend', () => {
   })
 
   test('shows message that frontend was enabled', async () => {
-    expectHasOkStatus(ressponse)
+    expect(ressponse.status).toBe(200)
     expect(await ressponse.text()).toBe('Enabled: Use of new frontend')
   })
 
@@ -600,7 +599,7 @@ describe('requests to /disable-frontend disable use of frontend', () => {
   })
 
   test('shows message that frontend use is disabled', async () => {
-    expectHasOkStatus(response)
+    expect(response.status).toBe(200)
     expect(await response.text()).toBe('Disabled: Use of new frontend')
   })
 

--- a/__tests__/utils.tsx
+++ b/__tests__/utils.tsx
@@ -38,7 +38,6 @@ import {
 } from '../src/utils'
 import {
   expectContainsText,
-  expectHasOkStatus,
   expectContentTypeIsHtml,
   expectIsJsonResponse,
   expectIsNotFoundResponse,
@@ -249,7 +248,7 @@ describe('markdownToHtml()', () => {
 test('PreactResponse', async () => {
   const hello = createPreactResponse(<h1>Hello</h1>)
 
-  expectHasOkStatus(hello)
+  expect(hello.status).toBe(200)
   expectContentTypeIsHtml(hello)
   await expectContainsText(hello, ['<h1>Hello</h1>'])
 


### PR DESCRIPTION
This makes the test more robust since this value should not differ
between requests (the original file stays the same). Google seems to
convert the image to other formats based on the user agent and probably
other things.

Other changes: https://github.com/serlo/serlo.org-cloudflare-worker/commit/880fc77979e581d55d90de236d1f0d7c022663ed and https://github.com/serlo/serlo.org-cloudflare-worker/pull/231/commits/04972ae8405f338cd2cb46098d277f515b98190a (explanations in commit messages) 