### PR TITLE
___ routes in frontend

### DIFF
--- a/__tests__/__utils__/services/frontend.ts
+++ b/__tests__/__utils__/services/frontend.ts
@@ -58,6 +58,8 @@ export function defaultFrontendServer(): RestResolver {
 
     if (req.url.pathname === '/___graphql') return res(ctx.body('graphiql'))
 
+    if (req.url.pathname === '/___funfunfun') return res(ctx.body('funfunfun'))
+
     const instance = req.url.pathname.substr(1, 2)
     const pathname = req.url.pathname.substr(3)
 

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -468,7 +468,7 @@ describe('special paths', () => {
     )
   })
 
-  test('/___graphql always resolve to frontend', async () => {
+  test('/___graphlql always resolve to frontend', async () => {
     const response = await env.fetch({
       subdomain: 'en',
       pathname: '/___graphql',
@@ -476,6 +476,16 @@ describe('special paths', () => {
 
     expect(response.status).toBe(200)
     expect(await response.text()).toEqual(expect.stringContaining('graphiql'))
+  })
+
+  test('links starting with /___ always resolve to frontend', async () => {
+    const response = await env.fetch({
+      subdomain: 'en',
+      pathname: '/___funfunfun',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toEqual(expect.stringContaining('funfunfun'))
   })
 
   describe('special paths where the cookie determines the backend', () => {

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -59,7 +59,7 @@ export async function frontendSpecialPaths(
     url.pathname.startsWith('/_next/') ||
     url.pathname.startsWith('/_assets/') ||
     url.pathname.startsWith('/api/frontend/') ||
-    url.pathname === '/___graphql'
+    url.pathname.startsWith('/___')
   )
     return await fetchBackend({ ...config, useFrontend: true, request, sentry })
 


### PR DESCRIPTION
currently there is `___graphql`, `___content` and the new `___replicants` and I'll make sure we add `noindex` tags to those pages.