### PR TITLE
Use KVNamespace instead of KV

### DIFF
--- a/__tests__/__utils__/kv.ts
+++ b/__tests__/__utils__/kv.ts
@@ -20,15 +20,28 @@
  * @link      https://github.com/serlo/serlo.org-cloudflare-worker for the canonical source repository
  */
 
-import type { KV } from '../../src/bindings'
-
-export function createKV<Key extends string>(): KV<Key> {
-  const values = {} as Record<Key, string | undefined>
+export function createKV<K extends string = string>(): KVNamespace<K> {
+  const values = {} as Record<K, string | undefined>
   return {
-    async get(key: Key): Promise<string | null> {
+    get(key: K, options?: unknown) {
+      if (options !== undefined) {
+        throw new Error(
+          'get function for type ${options.type} not yet implemented'
+        )
+      }
+
       return Promise.resolve(values[key] ?? null)
     },
-    async put(key: Key, value: string, _?: { expirationTtl: number }) {
+    getWithMetadata(_key: unknown, _options: unknown) {
+      throw new Error('not implemented')
+    },
+    list(_options) {
+      throw new Error('not implemented')
+    },
+    delete(_name) {
+      throw new Error('not implemented')
+    },
+    put(key, value: string, _) {
       if (key.length > 512) {
         throw new Error('Error: key longer than 512 characters.')
       }
@@ -36,5 +49,5 @@ export function createKV<Key extends string>(): KV<Key> {
 
       return Promise.resolve(undefined)
     },
-  }
+  } as KVNamespace<K>
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "@cloudflare/workers-types": "^3.0.0",
+    "@cloudflare/workers-types": "^3.3.1",
     "@cloudflare/wrangler": "^1.0.0",
     "@iarna/toml": "^2.0.0",
     "@splish-me/copyright-headers": "^0.0.2",

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -57,16 +57,7 @@ export interface Variables {
 
 // KVs
 declare global {
-  var MAINTENANCE_KV: KV<'enabled'>
-  var PACKAGES_KV: KV<string>
-  var PATH_INFO_KV: KV<import('./utils').CacheKey>
-}
-
-export interface KV<Key extends string> {
-  get: (key: Key) => Promise<string | null>
-  put: (
-    key: Key,
-    value: string,
-    options?: { expirationTtl: number }
-  ) => Promise<void>
+  var MAINTENANCE_KV: KVNamespace<'enabled'>
+  var PACKAGES_KV: KVNamespace<string>
+  var PATH_INFO_KV: KVNamespace<import('./utils').CacheKey>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,7 +1091,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudflare/workers-types@^3.0.0":
+"@cloudflare/workers-types@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.3.1.tgz#8847543bda320472252708c29aaf7bac3374e814"
   integrity sha512-GJFDgWd8ZHlr/m+Q2mp4xUl0/FIPpR6kf0Ix2C78E9HeJyUCW0c0w2EKCvgEDFFKB2rkzIX3eBqZCnLsbsw8zQ==


### PR DESCRIPTION
Closes https://github.com/serlo/serlo.org-cloudflare-worker/issues/242

This PR uses https://github.com/cloudflare/workers-types/pull/178 in order to delete the old `KV` interface. Thus `createKV` needed to be extended (each not implemented function returns an error).