### PR TITLE
Remove dependency "ramda"

### DIFF
--- a/__tests__/__utils__/services/api.ts
+++ b/__tests__/__utils__/services/api.ts
@@ -20,7 +20,6 @@
  * @link      https://github.com/serlo/serlo.org-cloudflare-worker for the canonical source repository
  */
 import { rest } from 'msw'
-import * as R from 'ramda'
 
 import { getUuid } from './database'
 import { RestResolver, createUrlRegex } from './utils'
@@ -64,7 +63,8 @@ export function defaultApiServer(): RestResolver<any> {
       return res(ctx.status(404, statusText))
     }
 
-    const result = R.omit(['oldAlias'], uuid)
+    const result = { ...uuid }
+    delete result['oldAlias']
 
     if (result.alias !== undefined)
       result.alias = encodeURIComponent(result.alias).replace(/%2F/g, '/')

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "marked": "^4.0.0",
     "preact": "^10.0.0",
     "preact-render-to-string": "^5.0.0",
-    "ramda": "^0.27.0",
     "sanitize-html": "^2.0.0",
     "toucan-js": "^2.5.0"
   },
@@ -61,7 +60,6 @@
     "@types/luxon": "^2.0.0",
     "@types/marked": "^4.0.0",
     "@types/node": "^16.0.0",
-    "@types/ramda": "^0.27.0",
     "@types/rimraf": "^3.0.0",
     "@types/sanitize-html": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/src/redirects.ts
+++ b/src/redirects.ts
@@ -19,8 +19,6 @@
  * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://github.com/serlo/serlo.org-cloudflare-worker for the canonical source repository
  */
-import { isNil } from 'ramda'
-
 import {
   createNotFoundResponse,
   getPathInfo,
@@ -71,7 +69,7 @@ export async function redirects(request: Request) {
 
   if (url.subdomain === 'meet') {
     const meetRedirect = meetRedirects[url.pathname]
-    return isNil(meetRedirect)
+    return meetRedirect == null
       ? createNotFoundResponse()
       : Response.redirect(`https://meet.google.com/${meetRedirect}`)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,13 +2531,6 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@^0.27.0":
-  version "0.27.64"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.64.tgz#7e23f2bf7b9729bcbd59223f100460ead6829008"
-  integrity sha512-EDf++ss/JoMiDpvT1MuA8oi88OwpvmqVE+o8Ojm5v/5bdJEPZ6eIQd/XYAeQ0imlwG6Tf0Npfq4Z9w3hAKBk9Q==
-  dependencies:
-    ts-toolbelt "^6.15.1"
-
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -9515,11 +9508,6 @@ ramda@^0.26.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
-ramda@^0.27.0:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
-  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -11154,11 +11142,6 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
-
-ts-toolbelt@^6.15.1:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
-  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 ts-unused-exports@^7.0.0:
   version "7.0.3"


### PR DESCRIPTION
Removes the dependency of ramda since it was used rarely. This should also make the build smaller and reduces the overall complexety of maintenance a little bit.