### PR TITLE
Enable `/user/settings` in frontend

### DIFF
--- a/__tests__/__utils__/services/frontend.ts
+++ b/__tests__/__utils__/services/frontend.ts
@@ -65,6 +65,8 @@ export function defaultFrontendServer(): RestResolver {
 
     if (pathname === '/user/notifications' && instance === 'en') {
       content = 'Notifications'
+    } else if (pathname === '/user/settings' && instance === 'en') {
+      content = 'Settings'
     } else if (pathname === '/spenden' && instance === 'de') {
       content = 'Spenden'
     } else if (pathname === '') {

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -321,6 +321,16 @@ describe('special paths', () => {
     )
   })
 
+  test('/user/settings always resolve to frontend', async () => {
+    const response = await env.fetch({
+      subdomain: 'en',
+      pathname: '/user/settings',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toEqual(expect.stringContaining('Settings'))
+  })
+
   test('/consent always resolve to frontend', async () => {
     const response = await env.fetch({
       subdomain: 'en',

--- a/scripts/run_all_checks.sh
+++ b/scripts/run_all_checks.sh
@@ -9,7 +9,7 @@ function init() {
   read_arguments "$@"
 
   print_header "Make sure yarn packages are up to date"
-  yarn install --frozen-lock
+  yarn install --immutable --immutable-cache
 }
 
 function read_arguments() {

--- a/src/utils/vercel-frontend-proxy.ts
+++ b/src/utils/vercel-frontend-proxy.ts
@@ -90,7 +90,11 @@ export function getRoute(request: Request): RouteConfig | null {
     }
   }
 
-  if (url.pathname === '/user/notifications' || url.pathname === '/consent') {
+  if (
+    url.pathname === '/user/notifications' ||
+    url.pathname === '/user/settings' ||
+    url.pathname === '/consent'
+  ) {
     return {
       __typename: 'BeforeRedirectsRoute',
       route: {


### PR DESCRIPTION
After finishing this I realised, that this could make '/user/settings/' unavailable even if `disable-frontend` is run.
Is that correct @kulla?
If yes… sorry :) Will try again tomorrow :)