### PR TITLE
handle `add-revision-old` as well

### DIFF
--- a/__tests__/__utils__/services/frontend.ts
+++ b/__tests__/__utils__/services/frontend.ts
@@ -78,7 +78,7 @@ export function defaultFrontendServer(): RestResolver {
       content = 'Event Log'
     } else if (req.url.pathname === '/en/entity/unrevised') {
       content = 'Unrevised Revisions'
-    } else if (req.url.pathname === '/en/entity/repository/add-revision') {
+    } else if (req.url.pathname === '/en/entity/repository/add-revision/123') {
       content = 'Edit Page'
     } else if (req.url.pathname === '/en/event/history/user/1/arekkas') {
       content = 'arekkas'

--- a/__tests__/__utils__/services/serlo.ts
+++ b/__tests__/__utils__/services/serlo.ts
@@ -51,6 +51,7 @@ export function defaultSerloServer(): RestResolver {
     } else if (url.pathname === '/license/detail/1') {
       content = ''
     } else if (url.pathname.startsWith('/entity/repository/add-revision')) {
+      // add-revision-old/… and add-revision/…
       content = ''
     } else {
       const uuid = getUuid(url.subdomain, url.pathname)

--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -331,10 +331,21 @@ describe('special paths', () => {
     expect(await response.text()).toEqual(expect.stringContaining('Consent'))
   })
 
-  test('GET /entity/repository/add-revision and useLegacyEditor cookie resolves to legacy', async () => {
+  test('GET /entity/repository/add-revision/123 resolves to frontend', async () => {
     const request = env.createRequest({
       subdomain: 'en',
-      pathname: '/entity/repository/add-revision',
+      pathname: '/entity/repository/add-revision/123',
+    })
+
+    const response = await env.fetchRequest(request)
+
+    await expectFrontend(response)
+  })
+
+  test('GET /entity/repository/add-revision/123 and useLegacyEditor cookie resolves to legacy', async () => {
+    const request = env.createRequest({
+      subdomain: 'en',
+      pathname: '/entity/repository/add-revision/123',
     })
 
     request.headers.set('Cookie', 'useLegacyEditor=1;authenticated=1')
@@ -343,11 +354,22 @@ describe('special paths', () => {
     await expectLegacy(response)
   })
 
-  test('POST /entity/repository/add-revision uses legacy', async () => {
+  test('GET /entity/repository/add-revision-old/123 resolves to legacy', async () => {
+    const request = env.createRequest({
+      subdomain: 'en',
+      pathname: '/entity/repository/add-revision-old/123',
+    })
+
+    const response = await env.fetchRequest(request)
+
+    await expectLegacy(response)
+  })
+
+  test('POST /entity/repository/add-revision/123 uses legacy', async () => {
     const request = env.createRequest(
       {
         subdomain: 'en',
-        pathname: '/entity/repository/add-revision',
+        pathname: '/entity/repository/add-revision/123',
       },
       { method: 'POST' }
     )

--- a/src/frontend-proxy.ts
+++ b/src/frontend-proxy.ts
@@ -139,7 +139,7 @@ async function getRoute(request: Request): Promise<RouteConfig | null> {
       ].includes(url.pathnameWithoutTrailingSlash) ||
       url.pathname.startsWith('/license/detail') ||
       url.pathname.startsWith('/entity/repository/history') ||
-      url.pathname.startsWith('/entity/repository/add-revision') ||
+      url.pathname.startsWith('/entity/repository/add-revision/') ||
       url.pathname.startsWith('/event/history')
     ) {
       return {

--- a/src/utils/vercel-frontend-proxy.ts
+++ b/src/utils/vercel-frontend-proxy.ts
@@ -103,9 +103,10 @@ export function getRoute(request: Request): RouteConfig | null {
   }
 
   if (
-    url.pathname.startsWith('/entity/repository/add-revision') &&
-    (request.method === 'POST' ||
-      getCookieValue('useLegacyEditor', cookies) === '1')
+    url.pathname.startsWith('/entity/repository/add-revision-old/') ||
+    (url.pathname.startsWith('/entity/repository/add-revision/') &&
+      (request.method === 'POST' ||
+        getCookieValue('useLegacyEditor', cookies) === '1'))
   ) {
     return {
       __typename: 'BeforeRedirectsRoute',


### PR DESCRIPTION
fix for https://github.com/serlo/frontend/issues/1500
if we actually deploy `use-legacy editor` tomorrow I guess it's okay to have this bug until then.