### PR TITLE
Forward /taxonomy/create to frontend only in GET (fixes #277)

### DIFF
--- a/__tests__/frontend-proxy.ts
+++ b/__tests__/frontend-proxy.ts
@@ -436,6 +436,23 @@ describe('special paths', () => {
       await expectFrontend(response)
     })
 
+    test('resolves to legacy in staging with POST', async () => {
+      global.ENVIRONMENT = 'staging'
+      const env = currentTestEnvironmentWhen(
+        (config) => config.ENVIRONMENT === 'staging'
+      )
+
+      const response = await env.fetch(
+        {
+          subdomain: 'de',
+          pathname: '/taxonomy/term/create/10/10',
+        },
+        { method: 'POST' }
+      )
+
+      await expectLegacy(response)
+    })
+
     test('resolves to Legacy in production', async () => {
       global.ENVIRONMENT = 'production'
       const env = currentTestEnvironmentWhen(

--- a/src/utils/vercel-frontend-proxy.ts
+++ b/src/utils/vercel-frontend-proxy.ts
@@ -138,7 +138,8 @@ export function getRoute(request: Request): RouteConfig | null {
 
   if (
     /\/taxonomy\/term\/create\/\d+\/\d+/.test(url.pathname) &&
-    global.ENVIRONMENT === 'staging'
+    global.ENVIRONMENT === 'staging' &&
+    request.method === 'GET'
   ) {
     return {
       __typename: 'Frontend',


### PR DESCRIPTION
Deployed already in staging...