### PR TITLE
New frontend by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,8 @@ MATOMO-OPT-OUT-FORM
 
 ## Frontend Proxy
 
-The cloudflare worker also provides an A-B-testing for the new frontend.
-The following variables define the behavior:
-
-- `FRONTEND_ALLOWED_TYPES`: List of resource types given by the Serlo API which can be redirected to the new frontend.
-- `FRONTEND_DOMAIN`: The domain of the new frontend.
-- `FRONTEND_PROBABILITY_MOBILE`: Probability that users with mobile devices are redirected to frontend (0-1).
-- `FRONTEND_PROBABILITY_DESKTOP`: Probability that users on desktop systems are redirected to frontend (0-1).
-- `FRONTEND_PROBABILITY_AUTHENTICATED`: Probability that authenticated users are redirected to frontend (0-1). Only works if `REDIRECT_AUTHENTICATED_USERS_TO_LEGACY_BACKEND` is `false`.
+The cloudflare worker redirects requests to the new frontend by default.
+For some paths or when the cookie `useLegacyFrontend` is set to `1` requests are directed to the legacy system.
 
 With the cookie `frontendDomain` you can override the variable of `FRONTEND_DOMAIN`.
 

--- a/__fixtures__/leagacy-serlo-pathnames.ts
+++ b/__fixtures__/leagacy-serlo-pathnames.ts
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Serlo.org Cloudflare Worker.
+ *
+ * Copyright (c) 2021 Serlo Education e.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright Copyright (c) 2021 Serlo Education e.V.
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/serlo/serlo.org-cloudflare-worker for the canonical source repository
+ */
+
+export const legacySerloPathnames = [
+  '/backend',
+  '/ads',
+  '/ads/ad/edit',
+  '/ads/add',
+  '/authentication/login',
+  '/authentication/logout',
+  '/authentication/password/change',
+  '/authorization/role/create',
+  '/authorization/role/permission/add',
+  '/authorization/role/show',
+  '/authorization/role/user/add',
+  '/authorization/roles',
+  '/blog',
+  '/blog/post/create',
+  '/blog/post/view',
+  '/blog/post/update',
+  '/flag/add',
+  '/flag/detail',
+  '/flag/manage',
+  '/license/add',
+  '/license/manage',
+  '/license/update',
+  '/navigation/container/create',
+  '/navigation/container/get',
+  '/navigation/manage',
+  '/navigation/page/get',
+  '/navigation/parameter/create',
+  '/navigation/parameter/key/create',
+  '/navigation/parameter/update',
+  '/page/create',
+  '/page/update',
+  '/pages',
+  '/taxonomy/term/action',
+  '/taxonomy/term/create',
+  '/taxonomy/term/organize-all',
+  '/taxonomy/term/organize',
+  '/taxonomy/term/sort-associated',
+  '/taxonomy/term/update',
+  '/user/register',
+  '/users',
+  '/uuid/recycle-bin',
+]

--- a/__tests__/__utils__/index.ts
+++ b/__tests__/__utils__/index.ts
@@ -29,7 +29,3 @@ export enum Backend {
   Frontend = 'frontend',
   Legacy = 'legacy',
 }
-
-export function setupProbabilityFor(backend: Backend) {
-  global.FRONTEND_PROBABILITY = backend === Backend.Frontend ? '1' : '0'
-}

--- a/__tests__/__utils__/services/serlo.ts
+++ b/__tests__/__utils__/services/serlo.ts
@@ -21,6 +21,7 @@
  */
 import { rest } from 'msw'
 
+import { legacySerloPathnames } from '../../../__fixtures__/leagacy-serlo-pathnames'
 import { Url, Instance } from '../../../src/utils'
 import { getUuid } from './database'
 import { RestResolver, createUrlRegex } from './utils'
@@ -36,12 +37,11 @@ export function defaultSerloServer(): RestResolver {
   return (req, res, ctx) => {
     const url = new Url(req.url.href)
 
-    if (url.pathname.startsWith('/auth/') || url.pathname === '/user/register')
-      return res(ctx.body(''))
-
     let content
 
-    if (url.pathname === '/spenden' && url.subdomain === 'de') {
+    if (url.pathname.startsWith('/auth/') || url.pathname === '/user/register')
+      content = 'Login'
+    else if (url.pathname === '/spenden' && url.subdomain === 'de') {
       content = 'Spenden'
     } else if (url.pathname === '/') {
       content =
@@ -56,6 +56,12 @@ export function defaultSerloServer(): RestResolver {
     } else if (url.pathname.startsWith('/entity/repository/add-revision')) {
       // add-revision-old/… and add-revision/…
       content = ''
+    } else if (
+      legacySerloPathnames.some((legacyPathname) =>
+        url.pathname.startsWith(legacyPathname)
+      )
+    ) {
+      content = 'Another Legacy Page'
     } else {
       const uuid = getUuid(url.subdomain, url.pathname)
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -61,7 +61,6 @@ beforeEach(() => {
   global.DOMAIN = 'serlo.local'
   global.ENVIRONMENT = 'local'
   global.FRONTEND_DOMAIN = 'frontend.serlo.local'
-  global.FRONTEND_PROBABILITY = '1'
 
   global.MAINTENANCE_KV = createKV()
   global.PATH_INFO_KV = createKV()

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -41,7 +41,6 @@ declare global {
   var ENVIRONMENT: string
   var ENABLE_BASIC_AUTH: 'true' | 'false'
   var FRONTEND_DOMAIN: string
-  var FRONTEND_PROBABILITY: string
 }
 
 // for tests, not sure how to share above types
@@ -52,7 +51,6 @@ export interface Variables {
   ENVIRONMENT: string
   ENABLE_BASIC_AUTH: 'true' | 'false'
   FRONTEND_DOMAIN: string
-  FRONTEND_PROBABILITY: string
 }
 
 // KVs

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,9 +5,9 @@ webpack_config = "webpack.config.js"
 
 [env.staging]
 kv-namespaces = [
-  { binding = "MAINTENANCE_KV", id = "3c3c25aba0b94b7e99f855f013f5b09c", preview_id = "3c3c25aba0b94b7e99f855f013f5b09c" },
-  { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be", preview_id = "19f90dc8e6ff49cd8bc42f51346409be" },
-  { binding = "PATH_INFO_KV", id = "839198b2f0a242b491e5723a8c59b7e2", preview_id = "839198b2f0a242b491e5723a8c59b7e2" },
+  {binding = "MAINTENANCE_KV", id = "3c3c25aba0b94b7e99f855f013f5b09c", preview_id = "3c3c25aba0b94b7e99f855f013f5b09c"},
+  {binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be", preview_id = "19f90dc8e6ff49cd8bc42f51346409be"},
+  {binding = "PATH_INFO_KV", id = "839198b2f0a242b491e5723a8c59b7e2", preview_id = "839198b2f0a242b491e5723a8c59b7e2"},
 ]
 name = "serlo-staging"
 route = "*serlo-staging.dev/*"
@@ -17,16 +17,15 @@ zone_id = "0067b08b108fbcf88ddaeaae4ac3d6ac"
 ALLOW_AUTH_FROM_LOCALHOST = "true"
 API_ENDPOINT = "https://api.serlo-staging.dev/graphql"
 DOMAIN = "serlo-staging.dev"
-ENVIRONMENT = "staging"
 ENABLE_BASIC_AUTH = "true"
+ENVIRONMENT = "staging"
 FRONTEND_DOMAIN = "frontend-git-staging-serlo.vercel.app"
-FRONTEND_PROBABILITY = "1"
 
 [env.production]
 kv-namespaces = [
-  { binding = "MAINTENANCE_KV", id = "b1f17ebbe39c4fd9b49d1368ce225faa" },
-  { binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be" },
-  { binding = "PATH_INFO_KV", id = "c3412114bdb04cfd8a367ec5bad46173" },
+  {binding = "MAINTENANCE_KV", id = "b1f17ebbe39c4fd9b49d1368ce225faa"},
+  {binding = "PACKAGES_KV", id = "19f90dc8e6ff49cd8bc42f51346409be"},
+  {binding = "PATH_INFO_KV", id = "c3412114bdb04cfd8a367ec5bad46173"},
 ]
 name = "serlo-production"
 route = "*serlo.org/*"
@@ -36,7 +35,6 @@ zone_id = "1a4afa776acb2e40c3c8a135248328ae"
 ALLOW_AUTH_FROM_LOCALHOST = "false"
 API_ENDPOINT = "https://api.serlo.org/graphql"
 DOMAIN = "serlo.org"
-ENVIRONMENT = "production"
 ENABLE_BASIC_AUTH = "false"
+ENVIRONMENT = "production"
 FRONTEND_DOMAIN = "frontend.serlo.org"
-FRONTEND_PROBABILITY = "1"


### PR DESCRIPTION
(for #262 and #279)
Unfinished first draft to change the frontend and vercel-frontend proxy code to redirect to the frontend by default.

**Caveats**
- There are suprisingly many legacy routes that might occur.
- This PR includes many but probably not all of them ( all that are defined in `packages/public/server/src/config/*` in the serlo.org repo)

