### PR TITLE
feat: add support for old comment link format

### DIFF
--- a/__tests__/redirects.ts
+++ b/__tests__/redirects.ts
@@ -427,22 +427,13 @@ describe('redirects to current path of an resource', () => {
   })
 
   test('redirects to article when old comment link is requested', async () => {
-    givenUuid({
-      id: 65395,
-      __typename: 'Comment',
-      alias: '/mathe/65395/65395',
-      legacyObject: { alias: '/mathe/1573/vektor' },
-    })
-
     const response = await env.fetch({
       subdomain: 'de',
       pathname: '/discussion/65395',
     })
 
-    const target = env.createUrl({
-      subdomain: 'de',
-      pathname: '/65395',
-    })
+    const target = env.createUrl({ subdomain: 'de', pathname: '/65395' })
+
     expectToBeRedirectTo(response, target, 301)
   })
 

--- a/__tests__/redirects.ts
+++ b/__tests__/redirects.ts
@@ -426,6 +426,26 @@ describe('redirects to current path of an resource', () => {
     expectToBeRedirectTo(response, target, 301)
   })
 
+  test('redirects to article when old comment link is requested', async () => {
+    givenUuid({
+      id: 65395,
+      __typename: 'Comment',
+      alias: '/mathe/65395/65395',
+      legacyObject: { alias: '/mathe/1573/vektor' },
+    })
+
+    const response = await env.fetch({
+      subdomain: 'de',
+      pathname: '/discussion/65395',
+    })
+
+    const target = env.createUrl({
+      subdomain: 'de',
+      pathname: '/65395',
+    })
+    expectToBeRedirectTo(response, target, 301)
+  })
+
   test('redirects to error when comment is deleted', async () => {
     givenUuid({
       id: 65395,

--- a/src/redirects.ts
+++ b/src/redirects.ts
@@ -149,6 +149,17 @@ export async function redirects(request: Request) {
     }
   }
 
+  if (isInstance(url.subdomain)) {
+    // support for legacy links to comment that are still used in mails
+    // `/discussion/{id}`
+    // can be deleted after we move the mailings
+    const match = /^\/discussion\/(\d+)$/.exec(url.pathname)
+    if (match) {
+      url.pathname = `/${match[1]}`
+      return url.toRedirect(301)
+    }
+  }
+
   if (
     isInstance(url.subdomain) &&
     request.headers.get('X-Requested-With') !== 'XMLHttpRequest'


### PR DESCRIPTION
in notification mails there are links of this format `/discussion/{commentId}`

@kulla after the redirect will they be handled by the cf-worker logic again?
So would `/discussion/65395` after this PR will lead the user to `/mathe/1573/vektor#comment-65395`? 