### PR TITLE
refactor!(redirects): Remove redirect for XMLHttpRequest

### DIFF
--- a/__tests__/redirects.ts
+++ b/__tests__/redirects.ts
@@ -281,15 +281,6 @@ describe('redirects to current path of an resource', () => {
     expectToBeRedirectTo(response, target, 301)
   })
 
-  test('no redirect when current path is different than given path and XMLHttpRequest', async () => {
-    const response = await env.fetch(
-      { subdomain: 'en', pathname: '/sexed' },
-      { headers: { 'X-Requested-With': 'XMLHttpRequest' } },
-    )
-
-    await expectContainsText(response, ['Sex Education'])
-  })
-
   test('no redirect when current path is the same as given path', async () => {
     const response = await env.fetch({
       subdomain: 'en',

--- a/src/redirects.ts
+++ b/src/redirects.ts
@@ -209,10 +209,7 @@ export async function redirects(request: Request, env: CFEnvironment) {
     }
   }
 
-  if (
-    isInstance(url.subdomain) &&
-    request.headers.get('X-Requested-With') !== 'XMLHttpRequest'
-  ) {
+  if (isInstance(url.subdomain)) {
     const pathInfo = await getPathInfo(url.subdomain, url.pathname, env)
 
     if (pathInfo !== null) {


### PR DESCRIPTION
When I recall correctely this was needed for legacy serlo.org. Thus, we can remove it now.