### PR TITLE
test: add failing test cases for geolocation redirect

### DIFF
--- a/__tests__/redirects.ts
+++ b/__tests__/redirects.ts
@@ -463,3 +463,51 @@ describe('redirects to current path of an resource', () => {
     expectToBeRedirectTo(response, target, 301)
   })
 })
+
+test('redirects to default exams landing page when no region is defined', async () => {
+  const response = await env.fetch({
+    subdomain: 'de',
+    pathname: '/pruefungen',
+  })
+
+  const target = env.createUrl({
+    subdomain: 'de',
+    pathname: '/pruefungen/bayern',
+  })
+
+  expectToBeRedirectTo(response, target, 302)
+})
+
+test('redirects to exams landing page bayern when bayern region is provided', async () => {
+  const response = await env.fetch(
+    {
+      subdomain: 'de',
+      pathname: '/pruefungen',
+    },
+    { cf: { regionCode: 'BY' } },
+  )
+
+  const target = env.createUrl({
+    subdomain: 'de',
+    pathname: '/pruefungen/bayern',
+  })
+
+  expectToBeRedirectTo(response, target, 302)
+})
+
+test('redirects to exams landing page niedersachsen when niedersachsen region is provided', async () => {
+  const response = await env.fetch(
+    {
+      subdomain: 'de',
+      pathname: '/pruefungen',
+    },
+    { cf: { regionCode: 'NI' } },
+  )
+
+  const target = env.createUrl({
+    subdomain: 'de',
+    pathname: '/pruefungen/niedersachsen',
+  })
+
+  expectToBeRedirectTo(response, target, 302)
+})

--- a/__tests__/redirects.ts
+++ b/__tests__/redirects.ts
@@ -467,12 +467,12 @@ describe('redirects to current path of an resource', () => {
 test('redirects to default exams landing page when no region is defined', async () => {
   const response = await env.fetch({
     subdomain: 'de',
-    pathname: '/pruefungen',
+    pathname: '/mathe-pruefungen',
   })
 
   const target = env.createUrl({
     subdomain: 'de',
-    pathname: '/pruefungen/bayern',
+    pathname: '/mathe-pruefungen/bayern',
   })
 
   expectToBeRedirectTo(response, target, 302)
@@ -482,14 +482,14 @@ test('redirects to exams landing page bayern when bayern region is provided', as
   const response = await env.fetch(
     {
       subdomain: 'de',
-      pathname: '/pruefungen',
+      pathname: '/mathe-pruefungen',
     },
     { cf: { regionCode: 'BY' } },
   )
 
   const target = env.createUrl({
     subdomain: 'de',
-    pathname: '/pruefungen/bayern',
+    pathname: '/mathe-pruefungen/bayern',
   })
 
   expectToBeRedirectTo(response, target, 302)
@@ -499,14 +499,14 @@ test('redirects to exams landing page niedersachsen when niedersachsen region is
   const response = await env.fetch(
     {
       subdomain: 'de',
-      pathname: '/pruefungen',
+      pathname: '/mathe-pruefungen',
     },
     { cf: { regionCode: 'NI' } },
   )
 
   const target = env.createUrl({
     subdomain: 'de',
-    pathname: '/pruefungen/niedersachsen',
+    pathname: '/mathe-pruefungen/niedersachsen',
   })
 
   expectToBeRedirectTo(response, target, 302)


### PR DESCRIPTION
`bayern` test works fine because of the fallback, but providing cf-region data in request does not work like this (undefined in function)
 
for https://github.com/serlo/cloudflare-worker/issues/679


@kulla do you happen to know how to provide this data?