### PR TITLE
chore(cors): Add failing test for port 3001

### DIFF
--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -77,6 +77,7 @@ describe('setting of response header `Access-Control-Allow-Origin`', () => {
   describe('when CORS is sent from the local frontend development or preview deployment', () => {
     const domains = [
       'http://localhost:3000',
+      'http://localhost:3001',
       'https://frontend-7md9ymhyw-serlo.vercel.app',
     ]
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -62,7 +62,8 @@ function getAllowedOrigin(requestOrigin: string | null, env: CFEnvironment) {
       if (
         url.domain === env.DOMAIN ||
         (env.ENVIRONMENT !== 'production' &&
-          ((url.domain === 'localhost' && (url.port === '3000' || url.port === '3001')) ||
+          ((url.domain === 'localhost' &&
+            (url.port === '3000' || url.port === '3001')) ||
             url.hostname.includes('-serlo.vercel.app')))
       ) {
         return requestOrigin

--- a/src/api.ts
+++ b/src/api.ts
@@ -62,7 +62,7 @@ function getAllowedOrigin(requestOrigin: string | null, env: CFEnvironment) {
       if (
         url.domain === env.DOMAIN ||
         (env.ENVIRONMENT !== 'production' &&
-          ((url.domain === 'localhost' && url.port === '3000') ||
+          ((url.domain === 'localhost' && (url.port === '3000' || url.port === '3001')) ||
             url.hostname.includes('-serlo.vercel.app')))
       ) {
         return requestOrigin


### PR DESCRIPTION
Reason: frontend devs sometimes work on port 3001