### PR TITLE
WIP: Enable CORS in API for integrations testing

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -65,7 +65,7 @@ function getAllowedOrigin(requestOrigin: string | null, env: CFEnvironment) {
           ((url.domain === 'localhost' &&
             (url.port === '3000' || url.port === '3001')) ||
             url.hostname.includes('-serlo.vercel.app'))) ||
-        url.domain === 'moodle-domain'
+        url.hostname.includes('.adornis.de')
       ) {
         return requestOrigin
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,7 +64,8 @@ function getAllowedOrigin(requestOrigin: string | null, env: CFEnvironment) {
         (env.ENVIRONMENT !== 'production' &&
           ((url.domain === 'localhost' &&
             (url.port === '3000' || url.port === '3001')) ||
-            url.hostname.includes('-serlo.vercel.app')))
+            url.hostname.includes('-serlo.vercel.app'))) ||
+        url.domain === 'moodle-domain'
       ) {
         return requestOrigin
       }


### PR DESCRIPTION
API PR: https://github.com/serlo/api.serlo.org/pull/1624
Frontend PR: https://github.com/serlo/frontend/pull/3915
Infra PR: https://github.com/serlo/infra/pull/90

A new "serlo-editor-testing" bucket is open for media uploaded while testing integrations of the Serlo Editor.

For that to work, CORS is enabled for all domains from which the Serlo Editor will be tested.