### PR TITLE
cloudflare: Increase expiration ttl of cache to 1 day

### DIFF
--- a/__tests__/current-alias-redirects.ts
+++ b/__tests__/current-alias-redirects.ts
@@ -220,11 +220,11 @@ describe('cache', () => {
     await expectCorrectRedirect()
   })
 
-  test('stores path for max 1 hour', async () => {
+  test('stores path for max 1 day', async () => {
     await expectCorrectRedirect()
 
     givenUuid({ __typename: 'Article', id: 42, alias: '/new-path' })
-    env.cfEnv.waitForSeconds(60 * 60 + 1)
+    env.cfEnv.waitForSeconds(60 * 60 * 24 + 1)
 
     const response = await env.fetch({ subdomain: 'de', pathname: '/42' })
     const target = env.createUrl({ subdomain: 'de', pathname: '/new-path' })

--- a/src/current-alias-redirects.ts
+++ b/src/current-alias-redirects.ts
@@ -152,7 +152,8 @@ async function getPathInfo(
   }
 
   await env.PATH_INFO_KV.put(cacheKey, JSON.stringify(result), {
-    expirationTtl: 60 * 60 * 24,
+    // randomize TTL a bit to avoid cache stampedes
+    expirationTtl: 60 * 60 * (16 + Math.random() * 8),
   })
 
   return result

--- a/src/current-alias-redirects.ts
+++ b/src/current-alias-redirects.ts
@@ -152,7 +152,7 @@ async function getPathInfo(
   }
 
   await env.PATH_INFO_KV.put(cacheKey, JSON.stringify(result), {
-    expirationTtl: 60 * 60,
+    expirationTtl: 60 * 60 * 24,
   })
 
   return result


### PR DESCRIPTION
Yesterday and today we had a problem with the rate limit. Therefore I increase the cache ttl to 1 day which should be fine right now.